### PR TITLE
FileFormatError removed from drgn introducing pylint error in sdb

### DIFF
--- a/sdb/internal/cli.py
+++ b/sdb/internal/cli.py
@@ -180,7 +180,6 @@ def setup_target(args: argparse.Namespace) -> drgn.Program:
         try:
             load_debug_info(prog, args.symbol_search)
         except (
-                drgn.FileFormatError,
                 drgn.MissingDebugInfoError,
                 OSError,
         ) as debug_info_err:


### PR DESCRIPTION
= Issue

Running `python3 -m pylint -d duplicate-code sdb` retuns the
following error:
```
sdb/internal/cli.py:183:16: E1101:
    Module 'drgn' has no 'FileFormatError' member (no-member)
```

The reason is that `drgn` removed this error from its interface
in the following commit:
```
commit 698991b27bb414283997701c441effdcdef11442
Author: Omar Sandoval <osandov@osandov.com>
Date:   Thu Aug 15 15:03:42 2019 -0700

Get rid of DRGN_ERROR_{ELF,DWARF}_ERROR and FileFormatError

We're too inconsistent with how we use these for them to be useful
(and it's impossible to distinguish between a format error and some
other error from libelf/libdw/libdwfl), so let's just get rid of
them and make it all DRGN_ERROR_OTHER/Exception.
```

= Fix

This patch resolves the issue by getting rid of the reference to
that error in cli.py.

= Verification/Tests

Ensured that `python3 -m pylint -d duplicate-code sdb` did not
return any errors.