### PR TITLE
Support for "evaluate and exit" CLI option

### DIFF
--- a/sdb/internal/cli.py
+++ b/sdb/internal/cli.py
@@ -80,6 +80,12 @@ def parse_arguments() -> argparse.Namespace:
         "don't load any debugging symbols that were not explicitly added with -s",
     )
 
+    parser.add_argument("-e",
+                        "--eval",
+                        metavar="CMD",
+                        type=str,
+                        action="store",
+                        help="evaluate CMD and exit")
     parser.add_argument("-q",
                         "--quiet",
                         action="store_true",
@@ -203,7 +209,11 @@ def main() -> None:
         return
 
     repl = REPL(prog, sdb.all_commands)
-    repl.run()
+    if args.eval:
+        exit_code = repl.eval_cmd(args.eval)
+        sys.exit(exit_code)
+    else:
+        repl.start_session()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
= Motivation

There are use cases where SDB needs to be part of a shell
pipeline and have its output saved and/or redirected for
further processing. An example use case from Delphix is
running an SDB command periodically from a shell script
and log its output. Today we can achieve this by doing
something like this:
```
$ echo 'addr spa_namespace_avl | member avl_root' | sdb
> *(struct avl_node *)0xffff8c1ce74f8108 = {
	.avl_child = (struct avl_node *[2]){},
	.avl_pcb = (uintptr_t)1,
}
>
```

The above is not ideal as it launches an actual REPL
session which ends because of the EOF when the end of
the input string is reached. This is not ideal for a
couple of reasons. First of all, the '>' prompts are
irrelevant and unneeded output. Most importantly though
we can have no clear semantics of when sdb should
return failure. For example:
```
$ echo 'addr bogus' | sdb
> sdb: addr: symbol not found: bogus
>
$ echo $?
0
```

The above is misleading because `addr`. Yet, returning
non-zero would also be misleading because the actual
SDB session did exactly what it was supposed to do (it
recovered from the command error).

= Patch

This patch introduces a new CLI option `-e` (mirroring
MDB's interface) where a single SDB command/pipeline
is passed as an argument and evaluated outside the
context of a REPL session, solving the above issue.

Normal case:
```
$ sdb -e 'addr spa_namespace_avl | member avl_root'
*(struct avl_node *)0xffff8c1ce74f8108 = {
	.avl_child = (struct avl_node *[2]){},
	.avl_pcb = (uintptr_t)1,
}
```

Error case - command failure:
```
$ sdb -e 'addr bogus'
sdb: addr: symbol not found: bogus
$ echo $?
1
```

Error case - invalid syntax/arguments:
```
$ sdb -e 'member'
usage: member [-h] <member> [<member> ...]
member: error: the following arguments are required: <member>
$ echo $?
2
```

= Testing

Besides the above manual testing, I also ran a few
interactive sessions to make sure that I didn't break
anything in the common code.