### PR TITLE
New pylint errors due to pylint upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,31 @@ install:
   - python3 -m pip install pytest
 
 script:
+  #
+  # We first record the version of everything we use as a baseline
+  # for future regressions introduced by these tools being upgraded.
+  #
+  - yapf --version
+  - pylint --version
+  - pytest --version
+  - python3 --version
+
+  #
+  # Ensure code is style and lint clean.
+  #
   - yapf --diff --style google --recursive sdb
   - yapf --diff --style google --recursive tests
   - pylint -d duplicate-code sdb
   - pylint -d duplicate-code tests
+
+  #
+  # Ensure there aren't new regressions in unit tests.
+  #
   - pytest -v tests
+
+  #
+  # Ensure installing sdb doesn't fail.
+  #
   - python3 setup.py install
 
 #

--- a/sdb/__init__.py
+++ b/sdb/__init__.py
@@ -15,6 +15,10 @@
 #
 """This module enables integration with the SDB REPL."""
 
+import shlex
+import subprocess
+import sys
+
 from typing import Dict, Type
 
 #
@@ -111,10 +115,6 @@ def invoke(prog: drgn.Program, first_input: Iterable[drgn.Object],
     # pylint: disable=too-many-locals
     # pylint: disable=too-many-branches
     # pylint: disable=too-many-statements
-
-    import shlex
-    import subprocess
-    import sys
 
     shell_cmd = None
     # Parse the argument string. Each pipeline stage is delimited by

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -139,4 +139,4 @@ def invoke(prog: drgn.Program, objs: Iterable[drgn.Object],
     Dispatch to sdb.invoke, but also drain the generator it returns, so
     the tests can more easily access the returned objects.
     """
-    return [i for i in sdb.invoke(prog, objs, line)]
+    return list(sdb.invoke(prog, objs, line))


### PR DESCRIPTION
= Description

While working on SDB in a new VM I hit the following
2 pylint issues. The problem is that newer versions
of pylint encounter more errors than before. This patch
fixes the two checks and also adds a few more commands
in the travis file to output the versions of everything
we use so TravisCI logs can be used as a reference.

= pylint issue #1

Error:
```
$ python3 -m pylint -d duplicate-code sdb
************* Module sdb
sdb/__init__.py:115:4: C0415: Import outside toplevel (shlex) (import-outside-toplevel)
sdb/__init__.py:116:4: C0415: Import outside toplevel (subprocess) (import-outside-toplevel)
sdb/__init__.py:117:4: C0415: Import outside toplevel (sys) (import-outside-toplevel)
```

From the reference:
```
import-outside-toplevel (C0415): Import outside toplevel (%s)
Used when an import statement is used anywhere other than the
module toplevel. Move this import to the top of the file.
```

Note: I actually preferred having the `shlex` and `subprocess`
imports within the method instead at the top of the file but
I figured I'd move them for now as `shlex` is going away and
`subprocess` will be moved around. Both of these changes will
be part of the new lexer code.

= pylint issue #2

Error:
```
$ python3 -m pylint -d duplicate-code tests/
************* Module tests
tests/__init__.py:142:0: R1721: Unnecessary use of a comprehension (unnecessary-comprehension)

------------------------------------------------------------------
Your code has been rated at 9.97/10 (previous run: 9.97/10, +0.00)
```

From the reference:
```
unnecessary-comprehension (R1721): Unnecessary use of a comprehension
Instead of using an identitiy comprehension, consider using the list,
dict or set constructor. It is faster and simpler.
```

= Differences in version

Old:
```
$ python3 -m pylint --version
__main__.py 2.3.1
astroid 2.2.5
Python 3.6.8 (default, Jan 14 2019, 11:02:34)
[GCC 8.0.1 20180414 (experimental) [trunk revision 259383]]
```

New:
```
$ python3 -m pylint --version
pylint 2.4.0
astroid 2.3.0
Python 3.6.8 (default, Aug 20 2019, 17:12:48)
[GCC 8.3.0]
```