### PR TITLE
Want dmesg command

### DIFF
--- a/sdb/commands/linux/__init__.py
+++ b/sdb/commands/linux/__init__.py
@@ -1,0 +1,26 @@
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# pylint: disable=missing-docstring
+
+import glob
+import importlib
+import os
+
+for path in glob.glob("{}/*.py".format(os.path.dirname(__file__))):
+    if path != __file__:
+        module = os.path.splitext(os.path.basename(path))[0]
+        importlib.import_module("sdb.commands.linux.{}".format(module))

--- a/sdb/commands/linux/dmesg.py
+++ b/sdb/commands/linux/dmesg.py
@@ -1,0 +1,58 @@
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# pylint: disable=missing-docstring
+
+from typing import Iterable
+
+import drgn
+import sdb
+
+
+class DMesg(sdb.Locator, sdb.PrettyPrinter):
+    # pylint: disable=too-few-public-methods
+
+    names = ["dmesg"]
+
+    input_type = "struct printk_log *"
+    output_type = "struct printk_log *"
+
+    def no_input(self) -> Iterable[drgn.Object]:
+        log_idx = self.prog["log_first_idx"]
+        log_seq = self.prog["clear_seq"]
+        log_end = self.prog["log_next_seq"]
+        log_buf = self.prog["log_buf"]
+
+        while log_seq < log_end:
+            entry = drgn.cast('struct printk_log *', log_buf + log_idx)
+
+            yield entry
+
+            if entry.len == 0:
+                log_idx = 0
+            else:
+                log_idx += entry.len
+            log_seq += 1
+
+    def pretty_print(self, objs: Iterable[drgn.Object]) -> None:
+        for obj in objs:
+            secs = int(obj.ts_nsec.value_() / 1000000000)
+            usecs = int((obj.ts_nsec.value_() % 1000000000) / 1000)
+
+            message = drgn.cast("char *", obj) + obj.type_.type.size
+            text = message.string_().decode('utf-8', 'ignore')
+
+            print("[{:5d}.{:06d}]: {:s}".format(secs, usecs, text))

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
     packages=[
         "sdb",
         "sdb.commands",
+        "sdb.commands.linux",
         "sdb.commands.zfs",
         "sdb.commands.zfs.internal",
         "sdb.internal",


### PR DESCRIPTION
= Motivation

The system log (`dmesg`) is easy to get from live-system but
we want to be able to acquire it from crash-dumps too because
this is where panic strings are generally printed.

= Patch

On a live-system:
```
$ sudo sdb -e 'dmesg'
[    0.000000]: Linux version 4.15.0-64-generic (buildd@lgw01-amd64-038) (gcc version 7.4.0 (Ubuntu 7.4.0-1ubuntu1~18.04.1)) #73-Ubuntu SMP Thu Sep 12 13:16:13 UTC 2019 (Ubuntu 4.15.0-64.73-generic 4.15.18)
[    0.000000]: Command line: BOOT_IMAGE=/ROOT/delphix.phT7XJd/root@/boot/vmlinuz-4.15.0-64-generic root=ZFS=rpool/ROOT/delphix.phT7XJd/root ro console=tty0 console=ttyS0,38400n8 mitigations=off ipv6.disable=1 crashkernel=256M,high crashkernel=256M,low
[    0.000000]: KERNEL supported cpus:
[    0.000000]:   Intel GenuineIntel
[    0.000000]:   AMD AuthenticAMD
[    0.000000]:   Centaur CentaurHauls
[    0.000000]: Disabled fast string operations
[    0.000000]: x86/fpu: Supporting XSAVE feature 0x001: 'x87 floating point registers'
...
[   30.320477]: Key type id_resolver registered
[   30.320478]: Key type id_legacy registered
[   32.982290]: Rounding down aligned max_sectors from 4294967295 to 4294967288
```

On a crash-dump:
```
$ sdb -s lib-modules-4.15.0-58-generic/ vmlinux-4.15.0-58-generic 201908192231/dump.201908192231
> dmesg
[ 4691.405102]: audit: type=1327 audit(1566253225.006:419650): proctitle=2F62696E2F7368002F6574632F7A66732F7A65642E642F616C6C2D7379736C6F672E7368
[ 4691.406366]: audit: type=1300 audit(1566253225.006:419651): arch=c000003e syscall=59 success=yes exit=0 a0=56451757b198 a1=56451757b060 a2=56451757b0c0 a3=7fdfbca98810 items=2 ppid=18098 pid=18106 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="logger" exe="/usr/bin/logger" key=(null)^CMD
[ 4691.406373]: audit: type=1309 audit(1566253225.006:419651): argc=11 a0="logger" a1="-p" a2="daemon.notice" a3="-t" a4="zed" a5="--" a6="eid=45034" a7="class=config_sync" a8="pool_guid=0xEA6C6446AA754856"
[ 4691.406374]: audit: type=1307 audit(1566253225.006:419651): cwd="/"
[ 4696.412754]: kauditd_printk_skb: 854 callbacks suppressedRxE
...
[ 5315.235157]: VERIFY(txg <= spa_final_dirty_txg(spa)) failed
[ 5315.237318]: PANIC at metaslab.c:3564:metaslab_sync()b
[ 5315.238211]: Kernel panic - not syncing: VERIFY(txg <= spa_final_dirty_txg(spa)) failed

[ 5315.239957]: CPU: 1 PID: 13268 Comm: txg_sync Tainted: P           OE    4.15.0-58-generic #64-Ubuntu
[ 5315.241648]: Hardware name: VMware, Inc. VMware Virtual Platform/440BX Desktop Reference Platform, BIOS 6.00 09/30/2014
[ 5315.243552]: Call Trace:
[ 5315.244154]:  dump_stack+0x63/0x8b
[ 5315.244876]:  panic+0xe4/0x244
[ 5315.245533]:  spl_panic+0x10f/0x110 [spl]?b
[ 5315.246571]:  ? __raw_spin_unlock+0x9/0x10 [zfs]
[ 5315.247547]:  ? dbuf_rele_and_unlock+0x364/0x4e0 [zfs]
[ 5315.248620]:  ? dmu_buf_rele+0xe/0x10 [zfs]
[ 5315.249549]:  ? zap_put_leaf+0x38/0x60 [zfs]
[ 5315.250577]:  ? fzap_lookup+0x129/0x140 [zfs]
[ 5315.251474]:  ? _cond_resched+0x19/0x40
[ 5315.252346]:  ? __kmalloc_node+0x21b/0x2c0
[ 5315.253347]:  metaslab_sync+0x63e/0x8b0 [zfs]؍
[ 5315.254342]:  ? getrawmonotonic+0x9/0x10 [zfs]
[ 5315.255446]:  vdev_sync+0x6f/0x190 [zfs]
[ 5315.256712]:  spa_sync_iterate_to_convergence+0x147/0x1e0 [zfs]
[ 5315.257847]:  spa_sync+0x327/0x5e0 [zfs]
[ 5315.258945]:  txg_sync_thread+0x28e/0x350 [zfs]
[ 5315.260103]:  ? txg_dispatch_callbacks+0x100/0x100 [zfs]
[ 5315.261238]:  thread_generic_wrapper+0x74/0x90 [spl]
[ 5315.262355]:  kthread+0x121/0x140f
[ 5315.263635]:  ? __thread_exit+0x20/0x20 [spl]S}
[ 5315.265123]:  ? kthread_create_worker_on_cpu+0x70/0x70
```