### PR TITLE
5 casting pointer to non-pointer results to crash

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -89,6 +89,7 @@ def setup_basic_mock_program() -> drgn.Program:
 
     prog.add_type_finder(mock_type_find)
 
+    global_int_addr = 0xffffffffc0000000
     global_struct_addr = 0xffffffffc0a8aee0
 
     def mock_object_find(prog: drgn.Program, name: str,
@@ -98,7 +99,7 @@ def setup_basic_mock_program() -> drgn.Program:
         assert flags == drgn.FindObjectFlags.ANY
 
         mock_objects = {
-            'global_int': (int_type, 0xffffffffc0a8aee0),
+            'global_int': (int_type, global_int_addr),
             'global_void_ptr': (voidp_type, 0xffff88d26353c108),
             'global_struct': (struct_type, global_struct_addr),
         }
@@ -115,8 +116,11 @@ def setup_basic_mock_program() -> drgn.Program:
         assert address == physical
         assert not offset
         fake_mappings = {
-            # address of global_struct and its first member ts_int
-            global_struct_addr: b'\x01\x00\x00\x00'
+            #
+            # Remember that our mocks are little-endian!
+            #
+            global_int_addr: b'\x04\x03\x02\x01',
+            global_struct_addr: b'\x01\x00\x00\x00',
         }
         assert address in fake_mappings
         assert count == len(fake_mappings[address])

--- a/tests/commands/test_address.py
+++ b/tests/commands/test_address.py
@@ -38,7 +38,7 @@ def test_single_object():
     ret = invoke(MOCK_PROGRAM, objs, line)
 
     assert len(ret) == 1
-    assert ret[0].value_() == 0xffffffffc0a8aee0
+    assert ret[0].value_() == 0xffffffffc0000000
     assert ret[0].type_ == MOCK_PROGRAM.type('int *')
 
 
@@ -60,7 +60,7 @@ def test_multiple_object():
     ret = invoke(MOCK_PROGRAM, objs, line)
 
     assert len(ret) == 3
-    assert ret[0].value_() == 0xffffffffc0a8aee0
+    assert ret[0].value_() == 0xffffffffc0000000
     assert ret[0].type_ == MOCK_PROGRAM.type('int *')
     assert ret[1].value_() == 0xffffffffc084eee0
     assert ret[1].type_ == MOCK_PROGRAM.type('void *')
@@ -75,7 +75,7 @@ def test_piped_invocations():
     ret = invoke(MOCK_PROGRAM, objs, line)
 
     assert len(ret) == 3
-    assert ret[0].value_() == 0xffffffffc0a8aee0
+    assert ret[0].value_() == 0xffffffffc0000000
     assert ret[0].type_ == MOCK_PROGRAM.type('int *')
     assert ret[1].value_() == 0xffffffffc084eee0
     assert ret[1].type_ == MOCK_PROGRAM.type('void *')

--- a/tests/commands/test_cast.py
+++ b/tests/commands/test_cast.py
@@ -1,0 +1,113 @@
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# pylint: disable=missing-docstring
+
+import pytest
+import sdb
+
+from tests import invoke, MOCK_PROGRAM
+
+
+def test_no_arg():
+    line = 'cast'
+    objs = []
+
+    with pytest.raises(sdb.CommandArgumentsError):
+        invoke(MOCK_PROGRAM, objs, line)
+
+
+def test_arg_no_pipe_input():
+    line = 'cast int'
+    objs = []
+
+    ret = invoke(MOCK_PROGRAM, objs, line)
+
+    assert not ret
+
+
+def test_arg_no_pipe_input_invalid_type():
+    line = 'cast bogus'
+    objs = []
+
+    with pytest.raises(sdb.CommandError) as err:
+        invoke(MOCK_PROGRAM, objs, line)
+
+    assert "could not find type 'bogus'" in str(err.value)
+
+
+def test_invoke_pipe_input():
+    line = 'cast void *'
+    objs = [MOCK_PROGRAM['global_int']]
+
+    ret = invoke(MOCK_PROGRAM, objs, line)
+
+    assert len(ret) == 1
+    assert ret[0].type_ == MOCK_PROGRAM.type('void *')
+    assert ret[0].value_() == 0x01020304
+
+
+def test_str_pipe_input():
+    line = 'addr global_int | cast void *'
+    objs = []
+
+    ret = invoke(MOCK_PROGRAM, objs, line)
+
+    assert len(ret) == 1
+    assert ret[0].type_ == MOCK_PROGRAM.type('void *')
+    assert ret[0].value_() == 0xffffffffc0000000
+
+
+def test_pipe_input_pointer_to_int():
+    line = 'addr global_int | cast unsigned int'
+    objs = []
+
+    ret = invoke(MOCK_PROGRAM, objs, line)
+
+    assert len(ret) == 1
+    assert ret[0].type_ == MOCK_PROGRAM.type('unsigned int')
+    assert ret[0].value_() == 0xc0000000
+
+
+def test_str_pipe_input_pointer_to_invalid_type():
+    line = 'addr global_int | cast bogus'
+    objs = []
+
+    with pytest.raises(sdb.CommandError) as err:
+        invoke(MOCK_PROGRAM, objs, line)
+
+    assert "could not find type 'bogus'" in str(err.value)
+
+
+def test_double_cast():
+    line = 'addr global_int | cast unsigned int | cast char *'
+    objs = []
+
+    ret = invoke(MOCK_PROGRAM, objs, line)
+
+    assert len(ret) == 1
+    assert ret[0].type_ == MOCK_PROGRAM.type('char *')
+    assert ret[0].value_() == 0xc0000000
+
+
+def test_pointer_to_struct():
+    line = 'addr global_int | cast struct test_struct'
+    objs = []
+
+    with pytest.raises(sdb.CommandError) as err:
+        invoke(MOCK_PROGRAM, objs, line)
+
+    assert "cannot convert 'int *' to 'struct test_struct'" in str(err.value)


### PR DESCRIPTION
5 casting pointer to non-pointer results to crash
13 `cast` can panic if passed an incorrect type

= Description

Even though minor, both of the above issues can become very
irritating as mispelling types (or forgetting the `struct`
prefix for C structues) drops the user out of the session.

= Patch

This patch changes the `cast` command to propagate the above
errors correctly without crashing the session. It also adds
tests cases for the command in our unit tests.

A side-fix for this commit is also the overlapping of the
`global_int` and `global_struct` mock symbols (e.g. they
were located in the same address within our mocked memory).

= Validation

Besides the test cases added, I performed manual validation.

Issue #5 before patch:
```
> echo 0xffff9c4fa3e90000 | cast spa_t
Traceback (most recent call last):
  File "/usr/local/bin/sdb", line 11, in <module>
    load_entry_point('sdb==0.1.0', 'console_scripts', 'sdb')()
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/cli.py", line 207, in main
    repl.run()
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/repl.py", line 86, in run
    for obj in objs:
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/__init__.py", line 180, in invoke
    yield from execute_pipeline(prog, first_input, pipeline)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/__init__.py", line 73, in execute_pipeline
    yield from pipeline[-1].call(this_input)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/commands/cast.py", line 52, in call
    yield drgn.cast(self.type, obj)
TypeError: cannot convert 'void *' to 'spa_t'
```

Issue #5 after patch:
```
> echo 0xffff9c4fa3e90000 | cast spa_t
sdb: cast: cannot convert 'void *' to 'spa_t'
>
```

Issue #13 before patch:
```
> echo 0xffff959ea62c0060 | cast struct kset_t *
Traceback (most recent call last):
  File "/usr/local/bin/sdb", line 11, in <module>
    load_entry_point('sdb==0.1.0', 'console_scripts', 'sdb')()
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/cli.py", line 216, in main
    repl.start_session()
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/repl.py", line 114, in start_session
    _ = self.eval_cmd(line)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/repl.py", line 87, in eval_cmd
    for obj in objs:
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/__init__.py", line 154, in invoke
    pipeline.append(all_commands[name](prog, args, name))
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/commands/cast.py", line 37, in __init__
    self.type = self.prog.type(" ".join(self.args.type))
LookupError: could not find 'struct kset_t'
```

Issue #13 after patch:
```
> echo 0xffff959ea62c0060 | cast struct kset_t *
sdb: cast: could not find type 'struct kset_t *'
>
```

= Github Issue Tracker Automation

Closes #5
Closes #13