### PR TITLE
Improve unit test mocks by introducing more complex structures

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -46,12 +46,18 @@ def create_struct_type(name: str, member_names: List[str],
     for member_name, type_ in zip(member_names, member_types):
         member_tuple = (type_, member_name, bit_offset, 0)
         member_list.append(member_tuple)
-        bit_offset += 8 * struct_size
-        struct_size += type_.size
+        if type_.kind == drgn.TypeKind.ARRAY:
+            bit_offset += 8 * type_.length * type_.type.size
+            struct_size += type_.length * type_.type.size
+        else:
+            bit_offset += 8 * type_.size
+            struct_size += type_.size
     return drgn.struct_type(name, struct_size, member_list)
 
 
 def setup_basic_mock_program() -> drgn.Program:
+    # pylint: disable=too-many-locals
+
     #
     # We specify an architecture here so we can have consistent
     # results through explicit assumptions like size of pointers
@@ -72,16 +78,14 @@ def setup_basic_mock_program() -> drgn.Program:
     # like int and void *.
     #
     int_type = prog.type('int')
+    int_array_type = prog.type('int[2]')
     voidp_type = prog.type('void *')
-    struct_type = create_struct_type('test_struct', ['ts_int', 'ts_voidp'],
-                                     [int_type, voidp_type])
+
+    mocked_types = {}
 
     def mock_type_find(kind: drgn.TypeKind, name: str,
                        filename: Optional[str]) -> Optional[drgn.Type]:
         assert filename is None
-        mocked_types = {
-            'test_struct': struct_type,
-        }
         if name in mocked_types:
             assert kind == mocked_types[name].kind
             return mocked_types[name]
@@ -89,8 +93,24 @@ def setup_basic_mock_program() -> drgn.Program:
 
     prog.add_type_finder(mock_type_find)
 
+    #
+    # More complex types are added to the mocked_types table in
+    # an ad-hoc way here.
+    #
+    struct_type = create_struct_type('test_struct',
+                                     ['ts_int', 'ts_voidp', 'ts_array'],
+                                     [int_type, voidp_type, int_array_type])
+    mocked_types['test_struct'] = struct_type
+    structp_type = prog.type('struct test_struct *')
+    complex_struct_type = create_struct_type(
+        'complex_struct', ['cs_structp', 'cs_struct', 'cs_structp_null'],
+        [structp_type, struct_type, structp_type])
+    mocked_types['complex_struct'] = complex_struct_type
+
+    global_void_ptr_addr = 0xffff88d26353c108
     global_int_addr = 0xffffffffc0000000
     global_struct_addr = 0xffffffffc0a8aee0
+    global_cstruct_addr = 0xffffffffd0000000
 
     def mock_object_find(prog: drgn.Program, name: str,
                          flags: drgn.FindObjectFlags,
@@ -99,9 +119,10 @@ def setup_basic_mock_program() -> drgn.Program:
         assert flags == drgn.FindObjectFlags.ANY
 
         mock_objects = {
+            'global_void_ptr': (voidp_type, global_void_ptr_addr),
             'global_int': (int_type, global_int_addr),
-            'global_void_ptr': (voidp_type, 0xffff88d26353c108),
             'global_struct': (struct_type, global_struct_addr),
+            'global_cstruct': (complex_struct_type, global_cstruct_addr),
         }
 
         if name in mock_objects:
@@ -111,22 +132,69 @@ def setup_basic_mock_program() -> drgn.Program:
 
     prog.add_object_finder(mock_object_find)
 
+    #
+    # Remember that our mocks are little-endian!
+    #
+    fake_mappings = {
+        #
+        # Initialize global_int in memory (value = 0x01020304).
+        #
+        global_int_addr:
+            b'\x04\x03\x02\x01',
+
+        #
+        # Initialize global_struct in memory.
+        # global_struct = {
+        #   .ts_int   = 0x00000001
+        #   .ts_voidp = <address of global_int>
+        #   .ts_array = [0x0f0f0f0f,  0xdeadbeef]
+        # }
+        #
+        global_struct_addr:
+            b'\x01\x00\x00\x00',
+        (global_struct_addr + int_type.size):
+            global_int_addr.to_bytes(8, byteorder='little'),
+        (global_struct_addr + int_type.size + voidp_type.size):
+            b'\x0f\x0f\x0f\x0f',
+        (global_struct_addr + (2 * int_type.size) + voidp_type.size):
+            b'\xef\xbe\xad\xde',
+
+        #
+        # Initialize global_cstruct in memory.
+        # global_cstruct = {
+        #   .cs_structp = <addres of global_struct>
+        #   .cs_struct  = {
+        #       .ts_int   = 0x0000000A
+        #       .ts_voidp = <address of global_cstruct>
+        #       .ts_array = [0x80000000,  0x7fffffff]
+        #   }
+        #   .cs_structp_null  = 0x0 (NULL)
+        # }
+        #
+        global_cstruct_addr:
+            global_struct_addr.to_bytes(8, byteorder='little'),
+        (global_cstruct_addr + structp_type.size):
+            b'\x0A\x00\x00\x00',
+        (global_cstruct_addr + structp_type.size + int_type.size):
+            global_cstruct_addr.to_bytes(8, byteorder='little'),
+        (global_cstruct_addr + structp_type.size + int_type.size + voidp_type.size):
+            b'\x00\x00\x00\x80',
+        (global_cstruct_addr + structp_type.size + (2 * int_type.size) + voidp_type.size):
+            b'\xff\xff\xff\x7f',
+        (global_cstruct_addr + structp_type.size + (3 * int_type.size) + voidp_type.size):
+            b'\x00\x00\x00\x00\x00\x00\x00\x00',
+    }
+
     def fake_memory_reader(address: int, count: int, physical: int,
                            offset: bool) -> bytes:
         assert address == physical
         assert not offset
-        fake_mappings = {
-            #
-            # Remember that our mocks are little-endian!
-            #
-            global_int_addr: b'\x04\x03\x02\x01',
-            global_struct_addr: b'\x01\x00\x00\x00',
-        }
         assert address in fake_mappings
         assert count == len(fake_mappings[address])
         return fake_mappings[address]
 
     prog.add_memory_segment(0, 0xffffffffffffffff, fake_memory_reader)
+
     return prog
 
 

--- a/tests/commands/test_member.py
+++ b/tests/commands/test_member.py
@@ -60,7 +60,7 @@ def test_member_not_found():
     assert "'struct test_struct' has no member 'bogus'" in str(err.value)
 
 
-def test_one_member():
+def test_first_member():
     line = 'addr global_struct | member ts_int'
     objs = []
 
@@ -70,3 +70,17 @@ def test_one_member():
     assert ret[0] == drgn.Object(MOCK_PROGRAM,
                                  MOCK_PROGRAM.type('int'),
                                  value=1)
+
+
+def test_second_member():
+    line = 'addr global_struct | member ts_voidp'
+    objs = []
+
+    ret = invoke(MOCK_PROGRAM, objs, line)
+
+    #
+    # We expect global_struct.ts_voidp to point to
+    # global_int (see comment on fake_mappings).
+    #
+    assert len(ret) == 1
+    assert ret[0] == MOCK_PROGRAM['global_int'].address_of_()


### PR DESCRIPTION
= Motivation

This change is part of a bigger change that I'm planning to
upstream soon - the new and improved `member` command. In
order to test the command more thoroughly I needed structures
in our mocks that are a bit more complex than the existing
one. As the code change grew bigger, I decided to split it
into the testing infrastructure part and the actual command
part.

= Patch

This patch introduces adds a new array field in the test_struct
structure, and then introduces another struct that contains
test_struct pointers and an embedded struct. All of these cases
will be used by the tests added together with the new `member`
command.

= Testing

Besides ensuring that current tests don't fail I manually
checked the values of all the new mocks from the python
REPL like this:
```
$ python3 -i tests/__init__.py

>>> print(MOCK_PROGRAM['global_struct'])
(struct test_struct){
        .ts_int = (int)1,
        .ts_voidp = (void *)0xffffffffc0000000,
        .ts_array = (int [2]){ 252645135, -559038737, },
}

>>> print(hex(MOCK_PROGRAM['global_int'].address_of_().value_()))
0xffffffffc0000000
>>> print(hex(MOCK_PROGRAM['global_struct'].ts_array[0]))
0xf0f0f0f
>>> print(hex(drgn.cast('unsigned int', MOCK_PROGRAM['global_struct'].ts_array[1])))
0xdeadbeef

>>> print(MOCK_PROGRAM['global_cstruct'])
(struct complex_struct){
        .cs_structp = (struct test_struct *)0xffffffffc0a8aee0,
        .cs_struct = (struct test_struct){
                .ts_int = (int)10,
                .ts_voidp = (void *)0xffffffffd0000000,
                .ts_array = (int [2]){ -2147483648, 2147483647, },
        },
        .cs_structp_null = (struct test_struct *)0x0,
}

>>> print(hex(MOCK_PROGRAM['global_struct'].address_of_().value_()))
0xffffffffc0a8aee0
>>> print(hex(MOCK_PROGRAM['global_cstruct'].address_of_().value_()))
0xffffffffd0000000
>>> print(hex(MOCK_PROGRAM['global_cstruct'].cs_struct.ts_array[0]))
-0x80000000
>>> print(hex(MOCK_PROGRAM['global_cstruct'].cs_struct.ts_array[1]))
0x7fffffff
>>> print(hex(MOCK_PROGRAM['global_cstruct'].cs_structp_null))
0x0
```