### PR TITLE
Introduce slabs command

### DIFF
--- a/sdb/commands/internal/__init__.py
+++ b/sdb/commands/internal/__init__.py
@@ -23,8 +23,8 @@ import os
 for path in glob.glob("{}/*.py".format(os.path.dirname(__file__))):
     if path != __file__:
         module = os.path.splitext(os.path.basename(path))[0]
-        importlib.import_module("sdb.commands.linux.{}".format(module))
+        importlib.import_module("sdb.commands.internal.{}".format(module))
 
 for path in glob.glob("{}/*/__init__.py".format(os.path.dirname(__file__))):
     module = os.path.basename(os.path.dirname(path))
-    importlib.import_module("sdb.commands.linux.{}".format(module))
+    importlib.import_module("sdb.commands.internal.{}".format(module))

--- a/sdb/commands/internal/fmt.py
+++ b/sdb/commands/internal/fmt.py
@@ -16,15 +16,13 @@
 
 # pylint: disable=missing-docstring
 
-import glob
-import importlib
-import os
+from typing import Union
 
-for path in glob.glob("{}/*.py".format(os.path.dirname(__file__))):
-    if path != __file__:
-        module = os.path.splitext(os.path.basename(path))[0]
-        importlib.import_module("sdb.commands.linux.{}".format(module))
 
-for path in glob.glob("{}/*/__init__.py".format(os.path.dirname(__file__))):
-    module = os.path.basename(os.path.dirname(path))
-    importlib.import_module("sdb.commands.linux.{}".format(module))
+def size_nicenum(num: Union[int, float]) -> str:
+    num = float(num)
+    for unit in ['B', 'KB', 'MB', 'GB', 'TB']:
+        if num < 1024.0:
+            return f"{num:.1f}{unit}"
+        num /= 1024.0
+    return f"{num:.1f}YB"

--- a/sdb/commands/internal/table.py
+++ b/sdb/commands/internal/table.py
@@ -1,0 +1,91 @@
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# pylint: disable=missing-docstring
+
+from typing import Any, Callable, Dict, List, Optional, Set
+
+
+class Table:
+    """
+    Generic Table implementation for pretty-printing
+    data in columns.
+    """
+
+    __slots__ = "fields", "rjustfields", "formatters", "maxfieldlen", "lines"
+
+    def __init__(self,
+                 fields: List[str],
+                 rjustfields: Optional[Set[str]] = None,
+                 formatters: Optional[Dict[str, Callable[[Any], str]]] = None
+                ) -> None:
+        self.fields = fields
+
+        if rjustfields is None:
+            self.rjustfields = ()
+        else:
+            self.rjustfields = rjustfields
+
+        self.formatters = {
+            field: (formatters[field] if field in formatters.keys() else str)
+            for field in fields
+        }
+        self.maxfieldlen = dict.fromkeys(fields, 0)
+        self.lines = []
+
+    def add_row(self, sortkey: Any, values: Dict[str, Any]) -> None:
+        row_values = []
+        for field in self.fields:
+            val = self.formatters[field](values[field])
+            row_values.append(val)
+            self.maxfieldlen[field] = max(self.maxfieldlen[field], len(val))
+        self.lines.append((sortkey, row_values))
+
+    def print_(self,
+               print_headers: Optional[bool] = True,
+               reverse_sort: Optional[bool] = False) -> None:
+        delimeter = "\t"
+        if print_headers:
+            delimeter = " "
+            headers, separators = [], []
+            for field in self.fields:
+                self.maxfieldlen[field] = max(self.maxfieldlen[field],
+                                              len(field))
+                if field in self.rjustfields:
+                    headers.append(f"{field:>{self.maxfieldlen[field]}}")
+                else:
+                    headers.append(f"{field:<{self.maxfieldlen[field]}}")
+                separators.append('-' * self.maxfieldlen[field])
+            print(delimeter.join(headers))
+            print(delimeter.join(separators))
+
+        self.lines.sort(reverse=reverse_sort)
+        for _, row_values in self.lines:
+            if not print_headers:
+                print(delimeter.join(row_values))
+                continue
+
+            line_fields = []
+            for fid in range(len(self.fields)):
+                if self.fields[fid] in self.rjustfields:
+                    line_fields.append(
+                        f"{row_values[fid]:>{self.maxfieldlen[self.fields[fid]]}}"
+                    )
+                else:
+                    line_fields.append(
+                        f"{row_values[fid]:<{self.maxfieldlen[self.fields[fid]]}}"
+                    )
+            print(delimeter.join(line_fields))

--- a/sdb/commands/linux/internal/__init__.py
+++ b/sdb/commands/linux/internal/__init__.py
@@ -23,8 +23,8 @@ import os
 for path in glob.glob("{}/*.py".format(os.path.dirname(__file__))):
     if path != __file__:
         module = os.path.splitext(os.path.basename(path))[0]
-        importlib.import_module("sdb.commands.linux.{}".format(module))
+        importlib.import_module("sdb.commands.linux.internal.{}".format(module))
 
 for path in glob.glob("{}/*/__init__.py".format(os.path.dirname(__file__))):
     module = os.path.basename(os.path.dirname(path))
-    importlib.import_module("sdb.commands.linux.{}".format(module))
+    importlib.import_module("sdb.commands.linux.internal.{}".format(module))

--- a/sdb/commands/linux/internal/slub_helpers.py
+++ b/sdb/commands/linux/internal/slub_helpers.py
@@ -1,0 +1,118 @@
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# pylint: disable=missing-docstring
+
+from typing import Iterable
+
+import drgn
+from drgn.helpers.linux.list import list_for_each_entry
+
+
+def is_root_cache(obj: drgn.Object) -> bool:
+    assert obj.type_.type_name() == 'struct kmem_cache *'
+    return obj.memcg_params.root_cache.value_() == 0x0
+
+
+def list_for_each_root_cache(prog: drgn.Program) -> Iterable[drgn.Object]:
+    yield from list_for_each_entry("struct kmem_cache",
+                                   prog["slab_root_caches"].address_of_(),
+                                   "memcg_params.__root_caches_node")
+
+
+def list_for_each_child_cache(root_cache: drgn.Object) -> Iterable[drgn.Object]:
+    assert root_cache.type_.type_name() == 'struct kmem_cache *'
+    yield from list_for_each_entry(
+        "struct kmem_cache", root_cache.memcg_params.children.address_of_(),
+        "memcg_params.children_node")
+
+
+def nr_slabs(obj: drgn.Object) -> int:
+    assert obj.type_.type_name() == 'struct kmem_cache *'
+    nslabs = obj.node[0].nr_slabs.counter.value_()
+    if not is_root_cache(obj):
+        return nslabs
+    for child in list_for_each_entry("struct kmem_cache",
+                                     obj.memcg_params.children.address_of_(),
+                                     "memcg_params.children_node"):
+        nslabs += nr_slabs(child)
+    return nslabs
+
+
+def entries_per_slab(obj: drgn.Object) -> int:
+    assert obj.type_.type_name() == 'struct kmem_cache *'
+    return obj.oo.x.value_() & 0xffff
+
+
+def entry_size(obj: drgn.Object) -> int:
+    assert obj.type_.type_name() == 'struct kmem_cache *'
+    return obj.size.value_()
+
+
+def object_size(obj: drgn.Object) -> int:
+    assert obj.type_.type_name() == 'struct kmem_cache *'
+    return obj.object_size.value_()
+
+
+def memused(obj: drgn.Object) -> int:
+    assert obj.type_.type_name() == 'struct kmem_cache *'
+    nslabs = nr_slabs(obj)
+    epslab = entries_per_slab(obj)
+    esize = entry_size(obj)
+    return nslabs * epslab * esize
+
+
+def objs(obj: drgn.Object) -> int:
+    assert obj.type_.type_name() == 'struct kmem_cache *'
+    count = obj.node[0].total_objects.counter.value_()
+    if not is_root_cache(obj):
+        return count
+    for child in list_for_each_entry("struct kmem_cache",
+                                     obj.memcg_params.children.address_of_(),
+                                     "memcg_params.children_node"):
+        count += objs(child)
+    return count
+
+
+def inactive_objs(obj: drgn.Object) -> int:
+    assert obj.type_.type_name() == 'struct kmem_cache *'
+    node = obj.node[0].partial
+    free = 0
+    for page in list_for_each_entry("struct page", node.address_of_(), "lru"):
+        free += page.objects.value_() - page.inuse.value_()
+
+    if not is_root_cache(obj):
+        return free
+
+    for child in list_for_each_entry("struct kmem_cache",
+                                     obj.memcg_params.children.address_of_(),
+                                     "memcg_params.children_node"):
+        free += inactive_objs(child)
+    return free
+
+
+def active_objs(obj: drgn.Object) -> int:
+    assert obj.type_.type_name() == 'struct kmem_cache *'
+    return objs(obj) - inactive_objs(obj)
+
+
+def util(obj: drgn.Object) -> int:
+    assert obj.type_.type_name() == 'struct kmem_cache *'
+    total = objs(obj)
+    if total == 0:
+        return 0
+    inactive = inactive_objs(obj)
+    return int(((total - inactive) / total) * 100)

--- a/sdb/commands/linux/slabs.py
+++ b/sdb/commands/linux/slabs.py
@@ -1,0 +1,191 @@
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# pylint: disable=missing-docstring
+
+import argparse
+import textwrap
+from typing import Any, Callable, Dict, Iterable, List
+
+import drgn
+
+import sdb
+from sdb.commands.internal.fmt import size_nicenum
+from sdb.commands.internal.table import Table
+from sdb.commands.linux.internal import slub_helpers as slub
+
+
+class Slabs(sdb.Locator, sdb.PrettyPrinter):
+    # pylint: disable=too-few-public-methods
+
+    names = ["slabs"]
+
+    input_type = "struct kmem_cache *"
+    output_type = "struct kmem_cache *"
+
+    def _init_argparse(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument(
+            '-H',
+            action='store_false',
+            help=
+            'do not display headers and separate fields by a single tab (scripted mode)'
+        )
+        parser.add_argument('-o',
+                            metavar="FIELDS",
+                            help='comma-separated list of fields to display')
+        parser.add_argument('-p',
+                            action='store_true',
+                            help='display numbers in parseable (exact) values')
+        parser.add_argument(
+            '-r',
+            '--recursive',
+            action='store_true',
+            help='recurse down children caches and print statistics')
+        parser.add_argument('-s', metavar="FIELD", help='sort rows by FIELD')
+        parser.add_argument('-v',
+                            action='store_true',
+                            help='Print all statistics')
+        #
+        # We change the formatter so we can add newlines in the epilog.
+        #
+        parser.formatter_class = argparse.RawDescriptionHelpFormatter
+        parser.epilog = textwrap.fill(
+            f"FIELDS := {', '.join(Slabs.FIELDS.keys())}\n",
+            width=80,
+            replace_whitespace=False)
+        parser.epilog += "\n\n"
+        parser.epilog += textwrap.fill(
+            ("If -o is not specified the default fields used are "
+             f"{', '.join(Slabs.DEFAULT_FIELDS)}.\n"),
+            width=80,
+            replace_whitespace=False)
+        parser.epilog += "\n\n"
+        parser.epilog += textwrap.fill(
+            ("If the -s option is not specified and the command's "
+             "output is not piped anywhere then we sort by the "
+             "following fields in order: "
+             f"{', '.join(Slabs.DEFAULT_SORT_FIELDS)}. "
+             "If none of those exists in the field-set we sort by "
+             "the first field specified in the set."),
+            width=80,
+            replace_whitespace=False)
+
+    def __no_input_iterator(self) -> Iterable[drgn.Object]:
+        for root_cache in slub.list_for_each_root_cache(self.prog):
+            yield root_cache
+            if self.args.recursive:
+                yield from slub.list_for_each_child_cache(root_cache)
+
+    def no_input(self) -> Iterable[drgn.Object]:
+        #
+        # If this command is not the last term of a pipeline (which
+        # means that the pretty-printing code won't run) we still
+        # need the `-s` option to work in order to sort the output
+        # that will be the input of the next command in the pipeline.
+        #
+        if self.args.s and not self.islast:
+            if self.args.s not in Slabs.FIELDS.keys():
+                raise sdb.CommandInvalidInputError(
+                    self.name, f"'{self.args.s}' is not a valid field")
+            yield from sorted(
+                self.__no_input_iterator(),
+                key=Slabs.FIELDS[self.args.s],
+                reverse=(
+                    self.args.s not in Slabs.DEFAULT_INCREASING_ORDER_FIELDS))
+        else:
+            yield from self.__no_input_iterator()
+
+    FIELDS = {
+        "address": lambda obj: hex(obj.value_()),
+        "name": lambda obj: obj.name.string_().decode('utf-8'),
+        "object_size": slub.object_size,
+        "entry_size": slub.entry_size,
+        "entries_per_slab": slub.entries_per_slab,
+        "slabs": slub.nr_slabs,
+        "mem_used": slub.memused,
+        "objs": slub.objs,
+        "active_objs": slub.active_objs,
+        "inactive_objs": slub.inactive_objs,
+        "util": slub.util,
+    }
+    DEFAULT_FIELDS = ["name", "entry_size", "objs", "mem_used", "util"]
+    DEFAULT_SORT_FIELDS = ["mem_used", "address", "name"]
+
+    #
+    # In general we prefer values to be sorted decreasing order
+    # (e.g. show me the slab caches that use up the most memory
+    # at the top) but there are certain fields like the ones
+    # below where it may make more sense to sort in increasing
+    # order like strings where we sort them alphabetically or
+    # pointers.
+    #
+    DEFAULT_INCREASING_ORDER_FIELDS = ["name", "address"]
+
+    def __pp_parse_args(self
+                       ) -> (str, List[str], Dict[str, Callable[[Any], str]]):
+        fields = self.DEFAULT_FIELDS
+        if self.args.o:
+            #
+            # HACK: Until we have a proper lexer for SDB we can
+            #       only pass the comma-separated list as a
+            #       string (e.g. quoted). Until this is fixed
+            #       we make sure to unquote such strings.
+            #
+            if self.args.o[0] == '"' and self.args.o[-1] == '"':
+                self.args.o = self.args.o[1:-1]
+            fields = self.args.o.split(",")
+        elif self.args.v:
+            fields = list(Slabs.FIELDS.keys())
+
+        for field in fields:
+            if field not in self.FIELDS:
+                raise sdb.CommandError(
+                    self.name, "'{:s}' is not a valid field".format(field))
+
+        sort_field = ""
+        if self.args.s:
+            if self.args.s not in fields:
+                msg = f"'{self.args.s}' is not in field set ({', '.join(fields)})"
+                raise sdb.CommandInvalidInputError(self.name,
+                                                   textwrap.fill(msg, width=80))
+            sort_field = self.args.s
+        else:
+            #
+            # If a sort_field hasn't been specified try the following
+            # defaults. If these are not part of the field-set then
+            # sort by the first field in the set.
+            #
+            for field in self.DEFAULT_SORT_FIELDS:
+                if field in fields:
+                    sort_field = field
+                    break
+            if not sort_field:
+                sort_field = fields[0]
+
+        formatters = {"mem_used": size_nicenum}
+        if self.args.p:
+            formatters = {}
+
+        return sort_field, fields, formatters
+
+    def pretty_print(self, objs: Iterable[drgn.Object]) -> None:
+        sort_field, fields, formatters = self.__pp_parse_args()
+        table = Table(fields, set(fields) - {"name"}, formatters)
+        for obj in objs:
+            row_dict = {field: Slabs.FIELDS[field](obj) for field in fields}
+            table.add_row(row_dict[sort_field], row_dict)
+        table.print_(print_headers=self.args.H,
+                     reverse_sort=(sort_field not in ["name", "address"]))

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,9 @@ setup(
     packages=[
         "sdb",
         "sdb.commands",
+        "sdb.commands.internal",
         "sdb.commands.linux",
+        "sdb.commands.linux.internal",
         "sdb.commands.zfs",
         "sdb.commands.zfs.internal",
         "sdb.internal",


### PR DESCRIPTION
= Motivation

`proc/slabinfo` is a useful tool for debugging out-of-memory
and fragmentation issues for the kernel. Unfortunately, it is
not applicable to crash dumps and not very user friendly overall
(e.g. you could figure out the memory usage of each cache and
its utilization but you have to do the math on your own).

Besides the above, the specific use-case within Delphix is a
replacement for `::kmastat` that we had in MDB in the illumos
version of the product. The `slabs` command introduced in this
commit is not a full replacement as it gives you only the
memory managed by the slab allocator (e.g. no memory zone, no
vmem info, etc..) and we still need to implement it for linux.
The idea here though, is to implement all the various memory
commands separately and then have `kmastat` finally consume
all the output from these commands.

= Patch

The main portion of this patch is the introduction of the slabs
command. By default the command iterates over the root caches
and prints the following statistics in human-readable form
sorted by memory used:
```
> slabs
name                        entry_size  objs mem_used util
--------------------------- ---------- ----- -------- ----
zfs_znode_cache                   1104 35224   37.1MB   99
dnode_t                            912 38284   33.3MB   99
zio_buf_14336                    16384  1916   29.9MB   99
kmalloc-512                        512 47824   23.4MB   93
dentry                             192 98112   18.0MB   97
...
```

All the properties can be seen in the help message and the user
may specify the properties they are looking for with the `-o`
option (and also sort them by a specific field using `-s`):
```
> slabs -h
usage: slabs [-h] [-H] [-o FIELDS] [-p] [-r] [-s FIELD] [-v]

optional arguments:
  -h, --help       show this help message and exit
  -H               do not display headers and separate fields by a single tab
                   (scripted mode)
  -o FIELDS        comma-separated list of fields to display
  -p               display numbers in parseable (exact) values
  -r, --recursive  recurse down children caches and print statistics
  -s FIELD         sort rows by FIELD
  -v               Print all statistics

FIELDS := address, name, object_size, entry_size, entries_per_slab, slabs,
mem_used, objs, active_objs, inactive_objs, util

If -o is not specified the default fields used are name, entry_size, objs,
mem_used, util.

If the -s option is not specified and the command's output is not piped anywhere
then we sort by the following fields in order: mem_used, address, name. If none
of those exists in the field-set we sort by the first field specified in the
set.

> slabs -o "name,object_size,slabs" -s object_size
name                        object_size slabs
--------------------------- ----------- -----
zio_buf_14336                     16384   957
zio_buf_10240                     12288    13
kmalloc-8192                       8192   527
dma-kmalloc-8192                   8192     0
net_namespace                      6912     2
...
```

Besides a PrettyPrinter, the command is also a Locator which
means that the user can do things like this:
```
> slabs | filter obj.name == "dma-kmalloc-192" | slabs
name            entry_size objs mem_used util
--------------- ---------- ---- -------- ----
dma-kmalloc-192        192    0     0.0B    0
```

The user can also use the `-r` option to traverse the children
of the root-caches recursively. Unfortunately, our `Table`
implementation doesn't support grouping entries together so
in our case we can't really group children caches and sort
them as one entry under their respective parent cache. This
has been left for future work and the current limited workaround
is to ensure that the entries are sorted by name:
```
> slabs -r -s name
name                                                       entry_size  objs mem_used util
---------------------------------------------------------- ---------- ----- -------- ----
AF_VSOCK                                                         1152    14   15.8KB  100
Acpi-Namespace                                                     40 46206    1.8MB   99
Acpi-Operand                                                       72  5488  385.9KB  100
Acpi-ParseExt                                                     104   156   15.8KB  100
Acpi-State                                                         80  5559  434.3KB   67
RAW                                                               960    34   31.9KB  100
TCP                                                              2048    96  192.0KB  100
anon_vma                                                           88 20654    1.7MB  100
anon_vma(107:systemd-remount-fs.service)                           88     0     0.0B    0
anon_vma(1086:systemd-tmpfiles-clean.service)                      88     0     0.0B    0
anon_vma(1118:motd-news.service)                                   88     0     0.0B    0
anon_vma(1158:motd-news.service)                                   88     0     0.0B    0
...
```

A couple more options mimicking Illumos conventions are the `-p`
and `-H` options that output numbers to raw form and skip printing
the headers respectively. This is generally useful for scripts or
output that is to be processed later:
```
> slabs -H -p
zfs_znode_cache	1104	35224	38887296	100
dnode_t	912	38318	34946016	99
zio_buf_14336	16384	1932	31653888	99
kmalloc-512	512	47824	24485888	93
dentry	192	98112	18837504	97
```

As part of the command's implementation, some generic infrastrure
was introduced in the repo. The `Table` class is the biggest
part of these changes, that is expected to be re-used by many
other commands. It was originally written by Matt Ahrens and I
had to edit it a bit to be Python3, yapf, and pylint compliant.
I also added the `formatters` field to support user-supplied
pretty-printers.

= Testing/Verification

I verified the values of all their fields in the following ways:
[1] For the fields that are also visible in /proc/slabinfo, I
    ensured that the values matched.
[2] For anything else I did the math and cross-referenced all
    the values ensuring that they are consistent with each other.

Besides the manual testing done shown in the output above I also
ensured the following error cases:

* ask for invalid field name
```
> slabs -o bogus
sdb: slabs: 'bogus' is not a valid field
```

* sort by invalid field name
```
> slabs -s bogus
sdb: slabs: invalid input: 'bogus' is not in field set (name, entry_size, objs, mem_used, util)
```

* attempt to sort by field that is not in the requested
field set
```
> slabs -o "name,address" -s objs
sdb: slabs: invalid input: 'objs' is not in field set (name, address)
```

= Other Notes

[1] The command currently only works with SLUB from kernel version
    4.15+. It will probably crash and burn with other allocators.
[2] Since we still don't do proper lexing in the SDB repl the `-o`
    option only works for multiple properties when these are
    quoted together as a string and there are not spaces between
    the fields/commas. To give an example:
    `> slabs -o name,util` <-- This doesn't work (yet).
    `> slabs -o "name, util"` <-- This doesn't work.
    `> slabs -o "name,util"` <-- This is the current workaround.