### PR TITLE
New pylint errors due to pylint upgrade

### DIFF
--- a/sdb/locator.py
+++ b/sdb/locator.py
@@ -89,6 +89,13 @@ class Locator(sdb.Command):
 
             # try walkers
             try:
+                # pylint: disable=import-outside-toplevel
+                #
+                # The reason we do the above is that putting
+                # the import at the top-level hits a cyclic
+                # import error which pretty-much breaks
+                # everything. We should reconsider how we
+                # handle all our imports.
                 from sdb.commands.walk import Walk
                 for obj in Walk(self.prog).call([i]):
                     yield drgn.cast(out_type, obj)


### PR DESCRIPTION
= Description

Master recently broke because of the same thing that happened
in commit 988c95b78474e65b9315d8d43719ed768697350c . This patch
fixes the issue brought up by pylint during the build.

= pylint issue

Error:
```
sdb/locator.py:92:16: C0415: Import outside toplevel (sdb.commands.walk) (import-outside-toplevel)
```

From the reference:
```
import-outside-toplevel (C0415): Import outside toplevel (%s)
Used when an import statement is used anywhere other than the
module toplevel. Move this import to the top of the file.
```

= Differences in version

Old:
```
0.61s$ pylint --version
pylint 2.4.2
astroid 2.3.1
Python 3.6.7 (default, Nov 28 2018, 13:38:24)
[GCC 5.4.0 20160609]
```

New:
```
$ pylint --version
pylint 2.4.3
astroid 2.3.2
Python 3.6.7 (default, Nov 28 2018, 13:38:24)
[GCC 5.4.0 20160609]
```