### PR TITLE
Rename existing slub cache walkers

### DIFF
--- a/sdb/commands/linux/internal/slub_helpers.py
+++ b/sdb/commands/linux/internal/slub_helpers.py
@@ -27,13 +27,13 @@ def is_root_cache(cache: drgn.Object) -> bool:
     return cache.memcg_params.root_cache.value_() == 0x0
 
 
-def list_for_each_root_cache(prog: drgn.Program) -> Iterable[drgn.Object]:
+def for_each_root_cache(prog: drgn.Program) -> Iterable[drgn.Object]:
     yield from list_for_each_entry("struct kmem_cache",
                                    prog["slab_root_caches"].address_of_(),
                                    "memcg_params.__root_caches_node")
 
 
-def list_for_each_child_cache(root_cache: drgn.Object) -> Iterable[drgn.Object]:
+def for_each_child_cache(root_cache: drgn.Object) -> Iterable[drgn.Object]:
     assert root_cache.type_.type_name() == 'struct kmem_cache *'
     yield from list_for_each_entry(
         "struct kmem_cache", root_cache.memcg_params.children.address_of_(),

--- a/sdb/commands/linux/slabs.py
+++ b/sdb/commands/linux/slabs.py
@@ -84,10 +84,10 @@ class Slabs(sdb.Locator, sdb.PrettyPrinter):
             replace_whitespace=False)
 
     def __no_input_iterator(self) -> Iterable[drgn.Object]:
-        for root_cache in slub.list_for_each_root_cache(self.prog):
+        for root_cache in slub.for_each_root_cache(self.prog):
             yield root_cache
             if self.args.recursive:
-                yield from slub.list_for_each_child_cache(root_cache)
+                yield from slub.for_each_child_cache(root_cache)
 
     def no_input(self) -> Iterable[drgn.Object]:
         #


### PR DESCRIPTION
= Motivation

Make the name shorter - there is no needed to expose
that they're implemented by lists (which could also
theoretically change in the future).

= Testing

Ensured that `slabs` and `slabs -r` runs as before.