### PR TITLE
Refactor parameter name in slub_helper and spl.kmem_helper

### DIFF
--- a/sdb/commands/spl/internal/kmem_helpers.py
+++ b/sdb/commands/spl/internal/kmem_helpers.py
@@ -30,105 +30,105 @@ def list_for_each_spl_kmem_cache(prog: drgn.Program) -> Iterable[drgn.Object]:
                                    "skc_list")
 
 
-def backed_by_linux_cache(obj: drgn.Object) -> bool:
-    assert obj.type_.type_name() == 'spl_kmem_cache_t *'
-    return obj.skc_linux_cache.value_() != 0x0
+def backed_by_linux_cache(cache: drgn.Object) -> bool:
+    assert cache.type_.type_name() == 'spl_kmem_cache_t *'
+    return cache.skc_linux_cache.value_() != 0x0
 
 
-def slab_name(obj: drgn.Object) -> str:
-    assert obj.type_.type_name() == 'spl_kmem_cache_t *'
-    return obj.skc_name.string_().decode('utf-8')
+def slab_name(cache: drgn.Object) -> str:
+    assert cache.type_.type_name() == 'spl_kmem_cache_t *'
+    return cache.skc_name.string_().decode('utf-8')
 
 
-def nr_slabs(obj: drgn.Object) -> int:
-    assert obj.type_.type_name() == 'spl_kmem_cache_t *'
-    return obj.skc_slab_total.value_()
+def nr_slabs(cache: drgn.Object) -> int:
+    assert cache.type_.type_name() == 'spl_kmem_cache_t *'
+    return cache.skc_slab_total.value_()
 
 
-def slab_alloc(obj: drgn.Object) -> int:
-    assert obj.type_.type_name() == 'spl_kmem_cache_t *'
-    return obj.skc_slab_alloc.value_()
+def slab_alloc(cache: drgn.Object) -> int:
+    assert cache.type_.type_name() == 'spl_kmem_cache_t *'
+    return cache.skc_slab_alloc.value_()
 
 
-def slab_size(obj: drgn.Object) -> int:
-    assert obj.type_.type_name() == 'spl_kmem_cache_t *'
-    return obj.skc_slab_size.value_()
+def slab_size(cache: drgn.Object) -> int:
+    assert cache.type_.type_name() == 'spl_kmem_cache_t *'
+    return cache.skc_slab_size.value_()
 
 
-def slab_linux_cache_source(obj: drgn.Object) -> str:
-    assert obj.type_.type_name() == 'spl_kmem_cache_t *'
-    if not backed_by_linux_cache(obj):
-        name = slab_name(obj)
+def slab_linux_cache_source(cache: drgn.Object) -> str:
+    assert cache.type_.type_name() == 'spl_kmem_cache_t *'
+    if not backed_by_linux_cache(cache):
+        name = slab_name(cache)
         subsystem = "SPL"
     else:
-        name = obj.skc_linux_cache.name.string_().decode('utf-8')
+        name = cache.skc_linux_cache.name.string_().decode('utf-8')
         subsystem = "SLUB"
     return f"{name}[{subsystem:4}]"
 
 
-def slab_flags(obj: drgn.Object) -> str:
-    assert obj.type_.type_name() == 'spl_kmem_cache_t *'
-    flag = obj.skc_flags.value_()
+def slab_flags(cache: drgn.Object) -> str:
+    assert cache.type_.type_name() == 'spl_kmem_cache_t *'
+    flag = cache.skc_flags.value_()
     flags_detected = []
-    for enum_entry, enum_entry_bit in obj.prog_.type(
+    for enum_entry, enum_entry_bit in cache.prog_.type(
             'enum kmc_bit').enumerators:
         if flag & (1 << enum_entry_bit):
             flags_detected.append(enum_entry.replace('_BIT', ''))
     return '|'.join(flags_detected)
 
 
-def object_size(obj: drgn.Object) -> int:
-    assert obj.type_.type_name() == 'spl_kmem_cache_t *'
-    return obj.skc_obj_size.value_()
+def object_size(cache: drgn.Object) -> int:
+    assert cache.type_.type_name() == 'spl_kmem_cache_t *'
+    return cache.skc_obj_size.value_()
 
 
-def nr_objects(obj: drgn.Object) -> int:
-    assert obj.type_.type_name() == 'spl_kmem_cache_t *'
-    if backed_by_linux_cache(obj):
-        return obj.skc_obj_alloc.value_()
-    return obj.skc_obj_total.value_()
+def nr_objects(cache: drgn.Object) -> int:
+    assert cache.type_.type_name() == 'spl_kmem_cache_t *'
+    if backed_by_linux_cache(cache):
+        return cache.skc_obj_alloc.value_()
+    return cache.skc_obj_total.value_()
 
 
-def obj_alloc(obj: drgn.Object) -> int:
-    assert obj.type_.type_name() == 'spl_kmem_cache_t *'
-    return obj.skc_obj_alloc.value_()
+def obj_alloc(cache: drgn.Object) -> int:
+    assert cache.type_.type_name() == 'spl_kmem_cache_t *'
+    return cache.skc_obj_alloc.value_()
 
 
-def obj_inactive(obj: drgn.Object) -> int:
-    assert obj.type_.type_name() == 'spl_kmem_cache_t *'
-    return nr_objects(obj) - obj_alloc(obj)
+def obj_inactive(cache: drgn.Object) -> int:
+    assert cache.type_.type_name() == 'spl_kmem_cache_t *'
+    return nr_objects(cache) - obj_alloc(cache)
 
 
-def objs_per_slab(obj: drgn.Object) -> int:
-    assert obj.type_.type_name() == 'spl_kmem_cache_t *'
-    return obj.skc_slab_objs.value_()
+def objs_per_slab(cache: drgn.Object) -> int:
+    assert cache.type_.type_name() == 'spl_kmem_cache_t *'
+    return cache.skc_slab_objs.value_()
 
 
-def entry_size(obj: drgn.Object) -> int:
-    assert obj.type_.type_name() == 'spl_kmem_cache_t *'
-    if backed_by_linux_cache(obj):
-        return slub.entry_size(obj.skc_linux_cache)
-    ops = objs_per_slab(obj)
+def entry_size(cache: drgn.Object) -> int:
+    assert cache.type_.type_name() == 'spl_kmem_cache_t *'
+    if backed_by_linux_cache(cache):
+        return slub.entry_size(cache.skc_linux_cache)
+    ops = objs_per_slab(cache)
     if ops == 0:
         return 0
-    return int(slab_size(obj) / objs_per_slab(obj))
+    return int(slab_size(cache) / objs_per_slab(cache))
 
 
-def active_memory(obj: drgn.Object) -> int:
-    assert obj.type_.type_name() == 'spl_kmem_cache_t *'
-    return obj_alloc(obj) * entry_size(obj)
+def active_memory(cache: drgn.Object) -> int:
+    assert cache.type_.type_name() == 'spl_kmem_cache_t *'
+    return obj_alloc(cache) * entry_size(cache)
 
 
-def total_memory(obj: drgn.Object) -> int:
-    assert obj.type_.type_name() == 'spl_kmem_cache_t *'
-    if backed_by_linux_cache(obj):
-        return slub.total_memory(obj.skc_linux_cache)
-    return slab_size(obj) * nr_slabs(obj)
+def total_memory(cache: drgn.Object) -> int:
+    assert cache.type_.type_name() == 'spl_kmem_cache_t *'
+    if backed_by_linux_cache(cache):
+        return slub.total_memory(cache.skc_linux_cache)
+    return slab_size(cache) * nr_slabs(cache)
 
 
-def util(obj: drgn.Object) -> int:
-    assert obj.type_.type_name() == 'spl_kmem_cache_t *'
-    total_mem = total_memory(obj)
+def util(cache: drgn.Object) -> int:
+    assert cache.type_.type_name() == 'spl_kmem_cache_t *'
+    total_mem = total_memory(cache)
     if total_mem == 0:
         return 0
-    return int((active_memory(obj) / total_mem) * 100)
+    return int((active_memory(cache) / total_mem) * 100)


### PR DESCRIPTION
= Motivation

The name `obj` as a parameter is too generic. `cache` is
more readable and intentional.

= Testing

Ensured that `slabs -v` and `spl_kmem_cache -v` didn't
crash.