### PR TITLE
Introduce count command

### DIFF
--- a/sdb/commands/count.py
+++ b/sdb/commands/count.py
@@ -1,0 +1,33 @@
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# pylint: disable=missing-docstring
+
+from typing import Iterable
+
+import drgn
+import sdb
+
+
+class Count(sdb.Command):
+    # pylint: disable=too-few-public-methods
+
+    names = ["count", "cnt", "wc"]
+
+    def call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
+        yield drgn.Object(self.prog,
+                          type='unsigned long long',
+                          value=sum(1 for _ in objs))

--- a/tests/commands/test_count.py
+++ b/tests/commands/test_count.py
@@ -1,0 +1,75 @@
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# pylint: disable=missing-docstring
+
+import drgn
+
+from tests import invoke, MOCK_PROGRAM
+
+
+def test_empty():
+    line = 'count'
+    objs = []
+
+    ret = invoke(MOCK_PROGRAM, objs, line)
+
+    assert len(ret) == 1
+    assert ret[0].value_() == 0
+
+
+def test_single_piped_input():
+    line = 'echo 0x0 | count'
+    objs = []
+
+    ret = invoke(MOCK_PROGRAM, objs, line)
+
+    assert len(ret) == 1
+    assert ret[0].value_() == 1
+
+
+def test_multiple_piped_inputs():
+    line = 'echo 0x0 0xfffff 0xdeadbeef 0x101010 | count'
+    objs = []
+
+    ret = invoke(MOCK_PROGRAM, objs, line)
+
+    assert len(ret) == 1
+    assert ret[0].value_() == 4
+
+
+def test_single_input():
+    line = 'count'
+    objs = [drgn.Object(MOCK_PROGRAM, 'void *', value=0)]
+
+    ret = invoke(MOCK_PROGRAM, objs, line)
+
+    assert len(ret) == 1
+    assert ret[0].value_() == 1
+
+
+def test_multiple_inputs():
+    line = 'count'
+    objs = [
+        drgn.Object(MOCK_PROGRAM, 'void *', value=0),
+        drgn.Object(MOCK_PROGRAM, 'int', value=0xfffff),
+        drgn.Object(MOCK_PROGRAM, 'unsigned long *', value=0xdeadbeef),
+    ]
+
+    ret = invoke(MOCK_PROGRAM, objs, line)
+
+    assert len(ret) == 1
+    assert ret[0].value_() == 3


### PR DESCRIPTION
= Motivation

Sometimes we want to count the number of objects a pipeline is
producing. For example, in ZFS we may want to know how many
metaslabs are currently loaded. We'd currently do that with
the following pipeline that breaks out to the UNIX shell:
```
> spa | member spa_metaslabs_by_flushed | addr | walk | cast metaslab_t * | filter obj.ms_loaded == 1 | member ms_loaded ! wc -l
11
```
The above is not that bad but imagine if the question was how
many root slab caches exist in the system? Doing `slabs ! wc -l`
would be off by 2 because `wc` would count the header line and
the header separator. `slabs -H ! wc -l` would work but rarely
people remember the `-H` option outside of scripts. Finally,
users may do something awkward like `slabs | member name ! wc -l`
or `slabs | cast void * ! wc -l`. Given the situation, we can
avoid doing any of the above if SDB just had a command that
can count the objects passed to it through the pipeline.

= Patch

This commit introduces `count` which does exactly that. The
above examples with this command change respective to:
```
> spa | member spa_metaslabs_by_flushed | addr | walk | cast metaslab_t * | filter obj.ms_loaded == 1 | count
(unsigned long long)9
```
and
```
> slabs | count
(unsigned long long)132
```

There is no reason currently why the command needs to return
an object (an unsigned long long to be specific). That said,
it would be nice to have in the future where SDB could have
a subshell syntax construct where an object would need to be
returned.

= Testing/Verification

A few unit tests are added by the patch. I did some manual
testing while poking around on a system while trying to develop
other SDB commands.