### PR TITLE
Fix `spa <poolname>` functionality

### DIFF
--- a/sdb/commands/zfs/spa.py
+++ b/sdb/commands/zfs/spa.py
@@ -61,10 +61,10 @@ class Spa(sdb.Locator, sdb.PrettyPrinter):
         parser.add_argument("poolnames", nargs="*")
 
     def pretty_print(self, spas):
-        print("{:14} {}".format("ADDR", "NAME"))
+        print("{:18} {}".format("ADDR", "NAME"))
         print("%s" % ("-" * 60))
         for spa in spas:
-            print("{:14} {}".format(hex(spa),
+            print("{:18} {}".format(hex(spa),
                                     spa.spa_name.string_().decode("utf-8")))
             if self.args.vdevs:
                 vdevs = sdb.execute_pipeline(self.prog, [spa],
@@ -78,7 +78,7 @@ class Spa(sdb.Locator, sdb.PrettyPrinter):
             [Avl(self.prog), Cast(self.prog, "spa_t *")],
         )
         for spa in spas:
-            if (self.args.poolnames and
-                    spa.spa_name.string_() not in self.args.poolnames):
+            if (self.args.poolnames and spa.spa_name.string_().decode("utf-8")
+                    not in self.args.poolnames):
                 continue
             yield spa


### PR DESCRIPTION
= Background

As part of the port from crash-python to drgn there was a bug
filed (issue #12) pointing out that `spa <poolname` stopped
working.
Example output:
```
> spa
ADDR           NAME
------------------------------------------------------------
0xffff959e94210000 rpool

> spa rpool
ADDR           NAME
------------------------------------------------------------
>
```

Another issue that's visible from this is that the header
of the second columnt ("NAME") is not aligned correctly.

= Patch

This pass fixes both issues and the command now looks like
this:
```
> spa
ADDR               NAME
------------------------------------------------------------
0xffff9d0adbe2c000 application
0xffff9d0a2dd28000 prod-data
0xffff9d0ae5040000 rpool
0xffff9d0a2bdb0000 support

> spa rpool
ADDR               NAME
------------------------------------------------------------
0xffff9d0ae5040000 rpool

> spa rpool | member spa_name
(char [256])"rpool"
```

= Testing

The only testing that I did was the manual testing above.

 = Github Issue Tracker Automation

Closes #12