### PR TITLE
Leverage Github Actions for automated testing 

### DIFF
--- a/.github/scripts/install-drgn.sh
+++ b/.github/scripts/install-drgn.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -eux
+
+#
+# These are build requirements of "drgn"; if we don't install these, the
+# build/install of "drgn" will fail below.
+#
+sudo apt-get install bison flex libelf-dev libdw-dev libomp-dev
+
+git clone https://github.com/osandov/drgn.git
+
+cd drgn
+python3 setup.py install
+cd -

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,61 @@
+on: push
+jobs:
+  #
+  # Verify the build and installation of SDB.
+  #
+  install:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.6'
+      - run: python3 setup.py install
+  #
+  # Verify "pylint" runs successfully.
+  #
+  # Note, we need to have "drgn" installed in order to run "pylint".
+  # Thus, prior to running "pylint" we have to clone, build, and install
+  # the "drgn" from source (there's no package currently available).
+  #
+  pylint:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.6'
+      - run: ./.github/scripts/install-drgn.sh
+      - run: python3 -m pip install pylint pytest
+      - run: pylint -d duplicate-code sdb
+      - run: pylint -d duplicate-code tests
+  #
+  # Verify "pytest" runs successfully.
+  #
+  # Note, we need to have "drgn" installed in order to "pytest". Thus,
+  # prior to running "pytest" we have to clone, build, and install the
+  # "drgn" from source (there's no package currently available).
+  #
+  pytest:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.6'
+      - run: ./.github/scripts/install-drgn.sh
+      - run: python3 -m pip install pytest
+      - run: pytest -v tests
+  #
+  # Verify "yapf" runs successfully.
+  #
+  yapf:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.6'
+      - run: python3 -m pip install yapf
+      - run: yapf --diff --style google --recursive sdb
+      - run: yapf --diff --style google --recursive tests

--- a/tests/commands/test_echo.py
+++ b/tests/commands/test_echo.py
@@ -16,8 +16,8 @@
 
 # pylint: disable=missing-docstring
 
-import drgn
 import pytest
+import drgn
 import sdb
 
 from tests import invoke, MOCK_PROGRAM

--- a/tests/commands/test_filter.py
+++ b/tests/commands/test_filter.py
@@ -16,8 +16,8 @@
 
 # pylint: disable=missing-docstring
 
-import drgn
 import pytest
+import drgn
 import sdb
 
 from tests import invoke, MOCK_PROGRAM

--- a/tests/commands/test_member.py
+++ b/tests/commands/test_member.py
@@ -16,8 +16,8 @@
 
 # pylint: disable=missing-docstring
 
-import drgn
 import pytest
+import drgn
 import sdb
 
 from tests import invoke, MOCK_PROGRAM


### PR DESCRIPTION
This change adds the necessary files and logic to take advantage of
GitHub Actions for running our automated tests. Currently we rely on
TravisCI to do this, but we'd like to transition over to GitHub Actions,
for the following reasons:

  1. The Actions UI is more integrated with GitHub PRs
  2. Best practices at Delphix suggests using Actions

While this change is adding support for using GitHub Actions, it's not
currently disabiling the use of TravisCI. Since I don't have much
experience with Actions, I'd like to use both Actions and TravisCI
simultaneously until we have sufficient confidence in Actions; at which
point we can disable the TravisCI tests, and rely solely on Actions.