### PR TITLE
Add an exit/quit command for sdb

### DIFF
--- a/sdb/commands/exit.py
+++ b/sdb/commands/exit.py
@@ -16,7 +16,7 @@
 
 # pylint: disable=missing-docstring
 
-import argparse
+import sys
 from typing import Iterable
 
 import drgn
@@ -29,4 +29,4 @@ class Echo(sdb.Command):
     names = ["exit", "quit"]
 
     def call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
-        exit()
+        sys.exit()

--- a/sdb/commands/exit.py
+++ b/sdb/commands/exit.py
@@ -16,7 +16,6 @@
 
 # pylint: disable=missing-docstring
 
-import sys
 from typing import Iterable
 
 import drgn
@@ -29,4 +28,4 @@ class Echo(sdb.Command):
     names = ["exit", "quit"]
 
     def call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
-        sys.exit()
+        raise SystemExit

--- a/sdb/commands/exit.py
+++ b/sdb/commands/exit.py
@@ -1,0 +1,32 @@
+#
+# Copyright 2019 Chuck Tuffli
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# pylint: disable=missing-docstring
+
+import argparse
+from typing import Iterable
+
+import drgn
+import sdb
+
+
+class Echo(sdb.Command):
+    # pylint: disable=too-few-public-methods
+
+    names = ["exit", "quit"]
+
+    def call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
+        exit()

--- a/sdb/internal/repl.py
+++ b/sdb/internal/repl.py
@@ -105,7 +105,7 @@ class REPL:
         while True:
             try:
                 line = input(self.prompt).strip()
-            except (EOFError, KeyboardInterrupt):
+            except (EOFError, KeyboardInterrupt, SystemExit):
                 print(self.closing)
                 break
 


### PR DESCRIPTION
At the OpenZFS hackathon, someone asked how to exit the debugger. This commit adds an explicit `exit` command in addition to the current `Ctrl-D`.