### PR TITLE
Use GitHub Actions for Pull Requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-on: push
+on: [push, pull_request]
 jobs:
   #
   # Verify the build and installation of SDB.


### PR DESCRIPTION
The prior commit to leverage GitHub Actions did not enable the use of
Actions for pull requests. This change adds the necessary configuration
so that we can use the same Actions to pushes to the repository itself,
as well as for any pending pull requests.