### PR TITLE
Fix argparse crash when opening dump from the same system

### DIFF
--- a/sdb/internal/cli.py
+++ b/sdb/internal/cli.py
@@ -66,7 +66,7 @@ def parse_arguments() -> argparse.Namespace:
         "-s",
         "--symbol-search",
         metavar="PATH",
-        type=str,
+        default=[],
         action="append",
         help="load debug info and symbols from the given directory or file;" +
         " this may option may be given more than once",
@@ -120,6 +120,7 @@ def parse_arguments() -> argparse.Namespace:
     #
     if args.object and not args.core:
         parser.error("raw object file target is not supported yet")
+
     return args
 
 
@@ -159,7 +160,7 @@ def setup_target(args: argparse.Namespace) -> drgn.Program:
         # or userland binary using the non-default debug info
         # load API.
         #
-        args.symbol_search.insert(0, args.object)
+        args.symbol_search = [args.object] + args.symbol_search
     elif args.pid:
         prog.set_pid(args.pid)
     else:


### PR DESCRIPTION
= Bug Description

There is a bug when trying to open a crash dump from the same
system that generated it (e.g. the user skips specifying where
the kernel module directories are with the -s option) crashes
SDB at startup.

= Root-cause

Looking at the actual failure below:
```
$ sudo sdb /boot/vmlinuz-4.15.0-65-generic dump.201910042034
Traceback (most recent call last):
  File "/usr/bin/sdb", line 11, in <module>
    load_entry_point('sdb==0.1.0', 'console_scripts', 'sdb')()
  File "/usr/lib/python3/dist-packages/sdb/internal/cli.py", line 206, in main
    prog = setup_target(args)
  File "/usr/lib/python3/dist-packages/sdb/internal/cli.py", line 162, in setup_target
    args.symbol_search.insert(0, args.object)
AttributeError: 'NoneType' object has no attribute 'insert'
```

The problem is that we expect `args.symbol_search` to exist as
a variable and we add the path of vmlinux to it (first argument
from the CLI) so drgn can import all the symbols and DWARF info.
That variable doesn't exist if the `-s` option is not used, thus
we fail with the above error when that option is not present.

= Fix

Ensure that this variable is set anyways even if `-s` is not
present.

= Testing

Before the patch:
```
$ sudo sdb  vmlinux-4.15.0-58-generic 201908192231/dump.201908192231
Traceback (most recent call last):
  File "/usr/local/bin/sdb", line 11, in <module>
    load_entry_point('sdb==0.1.0', 'console_scripts', 'sdb')()
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/cli.py", line 206, in main
    prog = setup_target(args)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/cli.py", line 162, in setup_target
    args.symbol_search.insert(0, args.object)
AttributeError: 'NoneType' object has no attribute 'insert'
```

After the patch:
```
$ sudo sdb  vmlinux-4.15.0-58-generic 201908192231/dump.201908192231
>
```

= Github Issue Tracker Automation

Closes #21