### PR TITLE
Fix exit command Class name

### DIFF
--- a/sdb/commands/exit.py
+++ b/sdb/commands/exit.py
@@ -22,8 +22,10 @@ import drgn
 import sdb
 
 
-class Echo(sdb.Command):
+class Exit(sdb.Command):
     # pylint: disable=too-few-public-methods
+
+    "Exit the application"
 
     names = ["exit", "quit"]
 


### PR DESCRIPTION
Fix problem noticed by @ahrens . Convention is class name should match the command name.