### PR TITLE
Introduce new "help" command

### DIFF
--- a/sdb/coerce.py
+++ b/sdb/coerce.py
@@ -32,7 +32,7 @@ class Coerce(sdb.Command):
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:
-        parser = super(Coerce, cls)._init_parser(name)
+        parser = super()._init_parser(name)
         #
         # We use REMAINDER here to allow the type to be specified
         # without the user having to worry about escaping whitespace.

--- a/sdb/coerce.py
+++ b/sdb/coerce.py
@@ -30,6 +30,19 @@ class Coerce(sdb.Command):
     to the appropriate pointer type.
     """
 
+    @classmethod
+    def _init_parser(cls, name: str) -> argparse.ArgumentParser:
+        parser = super(Coerce, cls)._init_parser(name)
+        #
+        # We use REMAINDER here to allow the type to be specified
+        # without the user having to worry about escaping whitespace.
+        # The drawback of this is an error will not be automatically
+        # thrown if no type is provided. To workaround this, we check
+        # the parsed arguments, and explicitly throw an error if needed.
+        #
+        parser.add_argument("type", nargs=argparse.REMAINDER)
+        return parser
+
     def __init__(self, prog: drgn.Program, args: str = "",
                  name: str = "_") -> None:
         super().__init__(prog, args, name)
@@ -41,17 +54,6 @@ class Coerce(sdb.Command):
         if self.type.kind is not drgn.TypeKind.POINTER:
             raise TypeError("can only coerce to pointer types, not {}".format(
                 self.type))
-
-    def _init_argparse(self, parser: argparse.ArgumentParser) -> None:
-        #
-        # We use REMAINDER here to allow the type to be specified
-        # without the user having to worry about escaping whitespace.
-        # The drawback of this is an error will not be automatically
-        # thrown if no type is provided. To workaround this, we check
-        # the parsed arguments, and explicitly throw an error if needed.
-        #
-        parser.add_argument("type", nargs=argparse.REMAINDER)
-        self.parser = parser
 
     def coerce(self, obj: drgn.Object) -> drgn.Object:
         """

--- a/sdb/command.py
+++ b/sdb/command.py
@@ -66,7 +66,7 @@ class Command:
             #
             if i == 0:
                 line = line.replace('usage: ', '')
-            print("    {}".format(line.replace('usage: ', '')))
+            print("    {}".format(line))
 
         if len(cls.names) > 1:
             print("ALIASES")
@@ -81,7 +81,7 @@ class Command:
         #
         if cls.__doc__:
             #
-            # The first line of the docstring is the summary, whichis
+            # The first line of the docstring is the summary, which is
             # already be included in the parser description. The second
             # line should be empty. Thus, we skip these two lines.
             #

--- a/sdb/command.py
+++ b/sdb/command.py
@@ -34,21 +34,67 @@ class Command:
 
     # pylint: disable=too-few-public-methods
 
+    @classmethod
+    def _init_parser(cls, name: str) -> argparse.ArgumentParser:
+        #
+        # If the class doesn't have a docstring, "inspect.getdoc" will
+        # pull from the parent class's docstring, if the parent class
+        # does have a docstring. This is not the behavior we want, so we
+        # first check "cls.__doc__" before using "inspect.getdoc".
+        #
+        if cls.__doc__:
+            summary = inspect.getdoc(cls).splitlines()[0].strip()
+        else:
+            summary = None
+        return argparse.ArgumentParser(prog=name, description=summary)
+
+    @classmethod
+    def help(cls, name: str):
+        """
+        This method will print a "help message" for the particular
+        command class that it's called on. The docstring and parser for
+        the class is used to populate the contents of the message.
+        """
+        parser = cls._init_parser(name)
+
+        print("SUMMARY")
+        for i, line in enumerate(parser.format_help().split('\n')):
+            #
+            # When printing the help message, the first line will have a
+            # "usage: " prefix string which looks awkward, so we strip
+            # that prefix prior to printing the first line.
+            #
+            if i == 0:
+                line = line.replace('usage: ', '')
+            print("    {}".format(line.replace('usage: ', '')))
+
+        if len(cls.names) > 1:
+            print("ALIASES")
+            print("    {}".format(", ".join(cls.names)))
+            print()
+
+        #
+        # If the class doesn't have a docstring, "inspect.getdoc" will
+        # pull from the parent class's docstring, if the parent class
+        # does have a docstring. This is not the behavior we want, so we
+        # first check "cls.__doc__" before using "inspect.getdoc".
+        #
+        if cls.__doc__:
+            #
+            # The first line of the docstring is the summary, whichis
+            # already be included in the parser description. The second
+            # line should be empty. Thus, we skip these two lines.
+            #
+            for line in inspect.getdoc(cls).splitlines()[2:]:
+                print("{}".format(line))
+            print()
+
     #
     # names:
     #    The potential names that can be used to invoke
     #    the command.
     #
     names: List[str] = []
-
-    #
-    # name:
-    #    The name used when the command was invoked. This
-    #    is generally used as a parameter passed to
-    #    exceptions raised by SDB to make error messages
-    #    more precise.
-    #
-    name: str = ""
 
     input_type: Optional[str] = None
 
@@ -63,9 +109,8 @@ class Command:
                 self.call).return_annotation == Iterable[drgn.Object]:
             self.ispipeable = True
 
-        parser = argparse.ArgumentParser(prog=name)
-        self._init_argparse(parser)
-        self.args = parser.parse_args(args.split())
+        self.parser = type(self)._init_parser(name)
+        self.args = self.parser.parse_args(args.split())
 
     def __init_subclass__(cls, **kwargs):
         """
@@ -76,9 +121,6 @@ class Command:
         super().__init_subclass__(**kwargs)
         for name in cls.names:
             sdb.register_command(name, cls)
-
-    def _init_argparse(self, parser: argparse.ArgumentParser) -> None:
-        pass
 
     def call(self,
              objs: Iterable[drgn.Object]) -> Optional[Iterable[drgn.Object]]:

--- a/sdb/commands/address.py
+++ b/sdb/commands/address.py
@@ -42,9 +42,11 @@ class Address(sdb.Command):
 
     names = ["address", "addr"]
 
-    def _init_argparse(self, parser: argparse.ArgumentParser) -> None:
-        super()._init_argparse(parser)
+    @classmethod
+    def _init_parser(cls, name: str) -> argparse.ArgumentParser:
+        parser = super(Address, cls)._init_parser(name)
         parser.add_argument("symbols", nargs="*", metavar="<symbol>")
+        return parser
 
     def call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
         for obj in objs:

--- a/sdb/commands/address.py
+++ b/sdb/commands/address.py
@@ -44,7 +44,7 @@ class Address(sdb.Command):
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:
-        parser = super(Address, cls)._init_parser(name)
+        parser = super()._init_parser(name)
         parser.add_argument("symbols", nargs="*", metavar="<symbol>")
         return parser
 

--- a/sdb/commands/cast.py
+++ b/sdb/commands/cast.py
@@ -28,6 +28,19 @@ class Cast(sdb.Command):
 
     names = ["cast"]
 
+    @classmethod
+    def _init_parser(cls, name: str) -> argparse.ArgumentParser:
+        parser = super(Cast, cls)._init_parser(name)
+        #
+        # We use REMAINDER here to allow the type to be specified
+        # without the user having to worry about escaping whitespace.
+        # The drawback of this is an error will not be automatically
+        # thrown if no type is provided. To workaround this, we check
+        # the parsed arguments, and explicitly throw an error if needed.
+        #
+        parser.add_argument("type", nargs=argparse.REMAINDER)
+        return parser
+
     def __init__(self, prog: drgn.Program, args: str = "",
                  name: str = "_") -> None:
         super().__init__(prog, args, name)
@@ -39,17 +52,6 @@ class Cast(sdb.Command):
             self.type = self.prog.type(tname)
         except LookupError:
             raise sdb.CommandError(self.name, f"could not find type '{tname}'")
-
-    def _init_argparse(self, parser: argparse.ArgumentParser) -> None:
-        #
-        # We use REMAINDER here to allow the type to be specified
-        # without the user having to worry about escaping whitespace.
-        # The drawback of this is an error will not be automatically
-        # thrown if no type is provided. To workaround this, we check
-        # the parsed arguments, and explicitly throw an error if needed.
-        #
-        parser.add_argument("type", nargs=argparse.REMAINDER)
-        self.parser = parser
 
     def call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
         for obj in objs:

--- a/sdb/commands/cast.py
+++ b/sdb/commands/cast.py
@@ -30,7 +30,7 @@ class Cast(sdb.Command):
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:
-        parser = super(Cast, cls)._init_parser(name)
+        parser = super()._init_parser(name)
         #
         # We use REMAINDER here to allow the type to be specified
         # without the user having to worry about escaping whitespace.

--- a/sdb/commands/echo.py
+++ b/sdb/commands/echo.py
@@ -28,8 +28,11 @@ class Echo(sdb.Command):
 
     names = ["echo", "cc"]
 
-    def _init_argparse(self, parser: argparse.ArgumentParser) -> None:
+    @classmethod
+    def _init_parser(cls, name: str) -> argparse.ArgumentParser:
+        parser = super(Echo, cls)._init_parser(name)
         parser.add_argument("addrs", nargs="*", metavar="<address>")
+        return parser
 
     def call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
         for obj in objs:

--- a/sdb/commands/echo.py
+++ b/sdb/commands/echo.py
@@ -30,7 +30,7 @@ class Echo(sdb.Command):
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:
-        parser = super(Echo, cls)._init_parser(name)
+        parser = super()._init_parser(name)
         parser.add_argument("addrs", nargs="*", metavar="<address>")
         return parser
 

--- a/sdb/commands/filter.py
+++ b/sdb/commands/filter.py
@@ -29,6 +29,12 @@ class Filter(sdb.Command):
 
     names = ["filter"]
 
+    @classmethod
+    def _init_parser(cls, name: str) -> argparse.ArgumentParser:
+        parser = super(Filter, cls)._init_parser(name)
+        parser.add_argument("expr", nargs=argparse.REMAINDER)
+        return parser
+
     def __init__(self, prog: drgn.Program, args: str = "",
                  name: str = "_") -> None:
         super().__init__(prog, args, name)
@@ -74,10 +80,6 @@ class Filter(sdb.Command):
             raise sdb.CommandEvalSyntaxError(self.name, err)
 
         self.compare = self.args.expr[index]
-
-    def _init_argparse(self, parser: argparse.ArgumentParser) -> None:
-        parser.add_argument("expr", nargs=argparse.REMAINDER)
-        self.parser = parser
 
     def call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
         try:

--- a/sdb/commands/filter.py
+++ b/sdb/commands/filter.py
@@ -31,7 +31,7 @@ class Filter(sdb.Command):
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:
-        parser = super(Filter, cls)._init_parser(name)
+        parser = super()._init_parser(name)
         parser.add_argument("expr", nargs=argparse.REMAINDER)
         return parser
 

--- a/sdb/commands/head.py
+++ b/sdb/commands/head.py
@@ -30,7 +30,7 @@ class Head(sdb.Command):
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:
-        parser = super(Head, cls)._init_parser(name)
+        parser = super()._init_parser(name)
         parser.add_argument("count", nargs="?", default=10, type=int)
         return parser
 

--- a/sdb/commands/head.py
+++ b/sdb/commands/head.py
@@ -28,8 +28,11 @@ class Head(sdb.Command):
 
     names = ["head"]
 
-    def _init_argparse(self, parser: argparse.ArgumentParser) -> None:
+    @classmethod
+    def _init_parser(cls, name: str) -> argparse.ArgumentParser:
+        parser = super(Head, cls)._init_parser(name)
         parser.add_argument("count", nargs="?", default=10, type=int)
+        return parser
 
     def call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
         for obj in objs:

--- a/sdb/commands/help.py
+++ b/sdb/commands/help.py
@@ -30,7 +30,7 @@ class Help(sdb.Command):
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:
-        parser = super(Help, cls)._init_parser(name)
+        parser = super()._init_parser(name)
         parser.add_argument("cmd", type=str)
         return parser
 

--- a/sdb/commands/help.py
+++ b/sdb/commands/help.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019 Delphix
+# Copyright 2019 Chuck Tuffli
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,27 +23,19 @@ import drgn
 import sdb
 
 
-class Member(sdb.Command):
+class Help(sdb.Command):
     # pylint: disable=too-few-public-methods
 
-    names = ["member"]
+    names = ["help"]
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:
-        parser = super(Member, cls)._init_parser(name)
-        parser.add_argument("members", nargs="+", metavar="<member>")
+        parser = super(Help, cls)._init_parser(name)
+        parser.add_argument("cmd", type=str)
         return parser
 
-    def call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
-        for obj in objs:
-            for member in self.args.members:
-                try:
-                    obj = obj.member_(member)
-                except (LookupError, TypeError) as err:
-                    #
-                    # The expected error messages that we get from
-                    # member_() are good enough to be propagated
-                    # as-is.
-                    #
-                    raise sdb.CommandError(self.name, str(err))
-            yield obj
+    def call(self, objs: Iterable[drgn.Object]) -> None:
+        try:
+            sdb.all_commands[self.args.cmd].help(self.args.cmd)
+        except KeyError:
+            raise sdb.error.CommandNotFoundError(self.args.cmd)

--- a/sdb/commands/linux/slabs.py
+++ b/sdb/commands/linux/slabs.py
@@ -36,7 +36,9 @@ class Slabs(sdb.Locator, sdb.PrettyPrinter):
     input_type = "struct kmem_cache *"
     output_type = "struct kmem_cache *"
 
-    def _init_argparse(self, parser: argparse.ArgumentParser) -> None:
+    @classmethod
+    def _init_parser(cls, name: str) -> argparse.ArgumentParser:
+        parser = super(Slabs, cls)._init_parser(name)
         parser.add_argument(
             '-H',
             action='store_false',
@@ -82,6 +84,7 @@ class Slabs(sdb.Locator, sdb.PrettyPrinter):
              "the first field specified in the set."),
             width=80,
             replace_whitespace=False)
+        return parser
 
     def __no_input_iterator(self) -> Iterable[drgn.Object]:
         for root_cache in slub.for_each_root_cache(self.prog):

--- a/sdb/commands/linux/slabs.py
+++ b/sdb/commands/linux/slabs.py
@@ -38,7 +38,7 @@ class Slabs(sdb.Locator, sdb.PrettyPrinter):
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:
-        parser = super(Slabs, cls)._init_parser(name)
+        parser = super()._init_parser(name)
         parser.add_argument(
             '-H',
             action='store_false',

--- a/sdb/commands/member.py
+++ b/sdb/commands/member.py
@@ -30,7 +30,7 @@ class Member(sdb.Command):
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:
-        parser = super(Member, cls)._init_parser(name)
+        parser = super()._init_parser(name)
         parser.add_argument("members", nargs="+", metavar="<member>")
         return parser
 

--- a/sdb/commands/pyfilter.py
+++ b/sdb/commands/pyfilter.py
@@ -30,7 +30,7 @@ class PyFilter(sdb.Command):
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:
-        parser = super(PyFilter, cls)._init_parser(name)
+        parser = super()._init_parser(name)
         parser.add_argument("expr", nargs=argparse.REMAINDER)
         return parser
 

--- a/sdb/commands/pyfilter.py
+++ b/sdb/commands/pyfilter.py
@@ -28,6 +28,12 @@ class PyFilter(sdb.Command):
 
     names = ["pyfilter"]
 
+    @classmethod
+    def _init_parser(cls, name: str) -> argparse.ArgumentParser:
+        parser = super(PyFilter, cls)._init_parser(name)
+        parser.add_argument("expr", nargs=argparse.REMAINDER)
+        return parser
+
     def __init__(self, prog: drgn.Program, args: str = "",
                  name: str = "_") -> None:
         super().__init__(prog, args, name)
@@ -38,10 +44,6 @@ class PyFilter(sdb.Command):
             self.code = compile(" ".join(self.args.expr), "<string>", "eval")
         except SyntaxError as err:
             raise sdb.CommandEvalSyntaxError(self.name, err)
-
-    def _init_argparse(self, parser: argparse.ArgumentParser) -> None:
-        parser.add_argument("expr", nargs=argparse.REMAINDER)
-        self.parser = parser
 
     def call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
         # pylint: disable=eval-used

--- a/sdb/commands/spl/spl_kmem_caches.py
+++ b/sdb/commands/spl/spl_kmem_caches.py
@@ -35,7 +35,9 @@ class SplKmemCaches(sdb.Locator, sdb.PrettyPrinter):
     input_type = "spl_kmem_cache_t *"
     output_type = "spl_kmem_cache_t *"
 
-    def _init_argparse(self, parser: argparse.ArgumentParser) -> None:
+    @classmethod
+    def _init_parser(cls, name: str) -> argparse.ArgumentParser:
+        parser = super(SplKmemCaches, cls)._init_parser(name)
         parser.add_argument(
             '-H',
             action='store_false',
@@ -81,6 +83,7 @@ class SplKmemCaches(sdb.Locator, sdb.PrettyPrinter):
              "the first field specified in the set."),
             width=80,
             replace_whitespace=False)
+        return parser
 
     def no_input(self) -> Iterable[drgn.Object]:
         #

--- a/sdb/commands/spl/spl_kmem_caches.py
+++ b/sdb/commands/spl/spl_kmem_caches.py
@@ -37,7 +37,7 @@ class SplKmemCaches(sdb.Locator, sdb.PrettyPrinter):
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:
-        parser = super(SplKmemCaches, cls)._init_parser(name)
+        parser = super()._init_parser(name)
         parser.add_argument(
             '-H',
             action='store_false',

--- a/sdb/commands/stacks.py
+++ b/sdb/commands/stacks.py
@@ -58,7 +58,7 @@ class Stacks(sdb.Command):
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:
-        parser = super(Stacks, cls)._init_parser(name)
+        parser = super()._init_parser(name)
         parser.add_argument(
             "-a",
             "--all",

--- a/sdb/commands/stacks.py
+++ b/sdb/commands/stacks.py
@@ -56,7 +56,9 @@ class Stacks(sdb.Command):
 
     names = ["stacks"]
 
-    def _init_argparse(self, parser: argparse.ArgumentParser) -> None:
+    @classmethod
+    def _init_parser(cls, name: str) -> argparse.ArgumentParser:
+        parser = super(Stacks, cls)._init_parser(name)
         parser.add_argument(
             "-a",
             "--all",
@@ -78,6 +80,7 @@ class Stacks(sdb.Command):
             help="only print threads which are in TSTATE thread state")
         parser.epilog = "TSTATE := [{:s}]".format(", ".join(
             Stacks.TASK_STATES.values()))
+        return parser
 
     #
     # See include/linux/sched.h

--- a/sdb/commands/tail.py
+++ b/sdb/commands/tail.py
@@ -29,8 +29,11 @@ class Tail(sdb.Command):
 
     names = ["tail"]
 
-    def _init_argparse(self, parser: argparse.ArgumentParser) -> None:
+    @classmethod
+    def _init_parser(cls, name: str) -> argparse.ArgumentParser:
+        parser = super(Tail, cls)._init_parser(name)
         parser.add_argument("count", nargs="?", default=10, type=int)
+        return parser
 
     def call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
         queue: Deque[drgn.Object] = deque(maxlen=self.args.count)

--- a/sdb/commands/tail.py
+++ b/sdb/commands/tail.py
@@ -31,7 +31,7 @@ class Tail(sdb.Command):
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:
-        parser = super(Tail, cls)._init_parser(name)
+        parser = super()._init_parser(name)
         parser.add_argument("count", nargs="?", default=10, type=int)
         return parser
 

--- a/sdb/commands/zfs/metaslab.py
+++ b/sdb/commands/zfs/metaslab.py
@@ -32,7 +32,9 @@ class Metaslab(sdb.Locator, sdb.PrettyPrinter):
     input_type = "metaslab_t *"
     output_type = "metaslab_t *"
 
-    def _init_argparse(self, parser: argparse.ArgumentParser) -> None:
+    @classmethod
+    def _init_parser(cls, name: str) -> argparse.ArgumentParser:
+        parser = super(Metaslab, cls)._init_parser(name)
         parser.add_argument(
             "-H",
             "--histogram",
@@ -48,6 +50,7 @@ class Metaslab(sdb.Locator, sdb.PrettyPrinter):
                             help="weight flag")
 
         parser.add_argument("metaslab_ids", nargs="*", type=int)
+        return parser
 
     @staticmethod
     def metaslab_weight_print(msp, print_header, indent):

--- a/sdb/commands/zfs/metaslab.py
+++ b/sdb/commands/zfs/metaslab.py
@@ -34,7 +34,7 @@ class Metaslab(sdb.Locator, sdb.PrettyPrinter):
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:
-        parser = super(Metaslab, cls)._init_parser(name)
+        parser = super()._init_parser(name)
         parser.add_argument(
             "-H",
             "--histogram",

--- a/sdb/commands/zfs/spa.py
+++ b/sdb/commands/zfs/spa.py
@@ -30,18 +30,9 @@ class Spa(sdb.Locator, sdb.PrettyPrinter):
     input_type = "spa_t *"
     output_type = "spa_t *"
 
-    def __init__(self, prog: drgn.Program, args: str = "",
-                 name: str = "_") -> None:
-        super().__init__(prog, args, name)
-        self.arg_string = ""
-        if self.args.metaslab:
-            self.arg_string += "-m "
-        if self.args.histogram:
-            self.arg_string += "-H "
-        if self.args.weight:
-            self.arg_string += "-w "
-
-    def _init_argparse(self, parser: argparse.ArgumentParser) -> None:
+    @classmethod
+    def _init_parser(cls, name: str) -> argparse.ArgumentParser:
+        parser = super(Spa, cls)._init_parser(name)
         parser.add_argument("-v",
                             "--vdevs",
                             action="store_true",
@@ -59,6 +50,18 @@ class Spa(sdb.Locator, sdb.PrettyPrinter):
                             action="store_true",
                             help="weight flag")
         parser.add_argument("poolnames", nargs="*")
+        return parser
+
+    def __init__(self, prog: drgn.Program, args: str = "",
+                 name: str = "_") -> None:
+        super().__init__(prog, args, name)
+        self.arg_string = ""
+        if self.args.metaslab:
+            self.arg_string += "-m "
+        if self.args.histogram:
+            self.arg_string += "-H "
+        if self.args.weight:
+            self.arg_string += "-w "
 
     def pretty_print(self, spas):
         print("{:18} {}".format("ADDR", "NAME"))

--- a/sdb/commands/zfs/spa.py
+++ b/sdb/commands/zfs/spa.py
@@ -32,7 +32,7 @@ class Spa(sdb.Locator, sdb.PrettyPrinter):
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:
-        parser = super(Spa, cls)._init_parser(name)
+        parser = super()._init_parser(name)
         parser.add_argument("-v",
                             "--vdevs",
                             action="store_true",

--- a/sdb/commands/zfs/vdev.py
+++ b/sdb/commands/zfs/vdev.py
@@ -30,16 +30,9 @@ class Vdev(sdb.Locator, sdb.PrettyPrinter):
     input_type = "vdev_t *"
     output_type = "vdev_t *"
 
-    def __init__(self, prog: drgn.Program, args: str = "",
-                 name: str = "_") -> None:
-        super().__init__(prog, args, name)
-        self.arg_string = ""
-        if self.args.histogram:
-            self.arg_string += "-H "
-        if self.args.weight:
-            self.arg_string += "-w "
-
-    def _init_argparse(self, parser: argparse.ArgumentParser) -> None:
+    @classmethod
+    def _init_parser(cls, name: str) -> argparse.ArgumentParser:
+        parser = super(Vdev, cls)._init_parser(name)
         parser.add_argument(
             "-m",
             "--metaslab",
@@ -63,6 +56,16 @@ class Vdev(sdb.Locator, sdb.PrettyPrinter):
                             help="weight flag")
 
         parser.add_argument("vdev_ids", nargs="*", type=int)
+        return parser
+
+    def __init__(self, prog: drgn.Program, args: str = "",
+                 name: str = "_") -> None:
+        super().__init__(prog, args, name)
+        self.arg_string = ""
+        if self.args.histogram:
+            self.arg_string += "-H "
+        if self.args.weight:
+            self.arg_string += "-w "
 
     def pretty_print(self, vdevs, indent=0):
         print(

--- a/sdb/commands/zfs/vdev.py
+++ b/sdb/commands/zfs/vdev.py
@@ -32,7 +32,7 @@ class Vdev(sdb.Locator, sdb.PrettyPrinter):
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:
-        parser = super(Vdev, cls)._init_parser(name)
+        parser = super()._init_parser(name)
         parser.add_argument(
             "-m",
             "--metaslab",

--- a/sdb/commands/zfs/zfs_dbgmsg.py
+++ b/sdb/commands/zfs/zfs_dbgmsg.py
@@ -31,8 +31,11 @@ class ZfsDbgmsg(sdb.Locator, sdb.PrettyPrinter):
     input_type = "zfs_dbgmsg_t *"
     output_type = "zfs_dbgmsg_t *"
 
-    def _init_argparse(self, parser: argparse.ArgumentParser) -> None:
+    @classmethod
+    def _init_parser(cls, name: str) -> argparse.ArgumentParser:
+        parser = super(ZfsDbgmsg, cls)._init_parser(name)
         parser.add_argument('--verbose', '-v', action='count', default=0)
+        return parser
 
     # obj is a zfs_dbgmsg_t*
     @staticmethod

--- a/sdb/commands/zfs/zfs_dbgmsg.py
+++ b/sdb/commands/zfs/zfs_dbgmsg.py
@@ -33,7 +33,7 @@ class ZfsDbgmsg(sdb.Locator, sdb.PrettyPrinter):
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:
-        parser = super(ZfsDbgmsg, cls)._init_parser(name)
+        parser = super()._init_parser(name)
         parser.add_argument('--verbose', '-v', action='count', default=0)
         return parser
 


### PR DESCRIPTION
This change adds a new "help" command that can be used to pring out
useful "help messages" for any particular SDB command. The contents of
the help message is derived automatically from the command class's
docstring and argument parser.

Co-authored-by: Prakash Surya <prakash.surya@delphix.com>