### PR TITLE
Add btree walker

### DIFF
--- a/sdb/commands/zfs/btree.py
+++ b/sdb/commands/zfs/btree.py
@@ -1,0 +1,85 @@
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# pylint: disable=missing-docstring
+
+from typing import Iterable
+
+import drgn
+import sdb
+
+
+class Btree(sdb.Walker):
+    """
+    walk zfs_btree
+
+    DESCRIPTION
+
+        btree_t's are used in ZFS, especially as metaslab range trees. Use walk or
+        zfs_btree for an in-order traversal of the contents of the tree.
+
+    EXAMPLES
+
+        > <metaslab_t *> | member ms_allocatable | walk | cast range_seg32_t *
+
+        *(range_seg32_t *)0xffff9990b5141d68 = {
+        .rs_start = (uint32_t)862981,
+        .rs_end = (uint32_t)868158,
+        }
+        *(range_seg32_t *)0xffff9990b5141d70 = {
+        .rs_start = (uint32_t)868163,
+        .rs_end = (uint32_t)939419,
+        }
+        *(range_seg32_t *)0xffff9990b5141d78 = {
+        .rs_start = (uint32_t)939424,
+        .rs_end = (uint32_t)1048576,
+        }
+    """
+
+    names = ["zfs_btree"]
+    input_type = "zfs_btree_t *"
+
+    def __init__(self, prog: drgn.Program, args: str = "",
+                 name: str = "_") -> None:
+        super().__init__(prog, args, name)
+        self.elem_size = None
+
+    def _val(self, start: int, idx: int) -> drgn.Object:
+        location = start + (self.elem_size * idx)
+        return drgn.Object(self.prog, type="void *", value=location)
+
+    def _helper(self, node: drgn.Object) -> Iterable[drgn.Object]:
+        if not node:
+            return
+
+        count = node.bth_count
+        if node.bth_core:
+            # alterate recursive descent on the children and generating core objects
+            core = drgn.cast('struct zfs_btree_core *', node)
+            for i in range(count):
+                yield from self._helper(core.btc_children[i])
+                yield self._val(core.btc_elems, i)
+            # descend the final, far-right child node
+            yield from self._helper(core.btc_children[count])
+        else:
+            # generate each object in the leaf elements
+            leaf = drgn.cast('struct zfs_btree_leaf *', node)
+            for i in range(count):
+                yield self._val(leaf.btl_elems, i)
+
+    def walk(self, obj: drgn.Object) -> Iterable[drgn.Object]:
+        self.elem_size = obj.bt_elem_size
+        yield from self._helper(obj.bt_root)


### PR DESCRIPTION
Add btree walker: https://github.com/delphix/sdb/issues/28. This is based on ZFS's btree implementation: https://github.com/zfsonlinux/zfs/blob/master/include/sys/btree.h

I've tested it on `ms_allocatable` trees. I was able to verify that it finds the correct number of elements:
```
*(zfs_btree_t *)0xffff9268a76e3800 = {
	.bt_root = (zfs_btree_hdr_t *)0xffff9268a89fa000,
	.bt_height = (int64_t)1,
	.bt_elem_size = (size_t)8,
	.bt_num_elems = (uint64_t)2436,
	.bt_num_nodes = (uint64_t)8,
	.bt_bulk = (zfs_btree_leaf_t *)0x0,
	.bt_compar = (int (*)(const void *, const void *))0xffffffffc0465b50,
}
> echo 0xffff9268a76e3800 | cast zfs_btree_t * | walk | cast range_seg32_t * |count
(unsigned long long)2436
```
And, based on visual inspection, that it produces elements in sorted order:
```
 echo 0xffff9268a76e3800 | cast zfs_btree_t * | walk | cast range_seg32_t * 
*(range_seg32_t *)0xffff9268a711d010 = {
	.rs_start = (uint32_t)129111,
	.rs_end = (uint32_t)129119,
}
*(range_seg32_t *)0xffff9268a711d018 = {
	.rs_start = (uint32_t)129143,
	.rs_end = (uint32_t)129157,
}
...
*(range_seg32_t *)0xffff92672dfd5d58 = {
	.rs_start = (uint32_t)1048346,
	.rs_end = (uint32_t)1048576,
}
```
I'm open to other suggestions on how to test this, especially on trees with greater depth. 