### PR TITLE
change default prompt to sdb>

### DIFF
--- a/sdb/internal/repl.py
+++ b/sdb/internal/repl.py
@@ -51,7 +51,7 @@ class REPL:
 
         return custom_complete
 
-    def __init__(self, target, vocabulary, prompt="> ", closing=""):
+    def __init__(self, target, vocabulary, prompt="sdb> ", closing=""):
         self.prompt = prompt
         self.closing = closing
         self.vocabulary = vocabulary


### PR DESCRIPTION
Closes #22

```
$ sudo sdb
sdb: could not get debugging information for:
/lib/modules/4.15.0-66-generic/kernel/net/connstat/connstat.ko (libdwfl error: No DWARF information found)
sdb> echo 1 2 3 | count
(unsigned long long)3
sdb>
```