### PR TITLE
add dbuf locator / pretty-printer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,8 +27,8 @@ jobs:
           python-version: '3.6'
       - run: ./.github/scripts/install-drgn.sh
       - run: python3 -m pip install pylint pytest
-      - run: pylint -d duplicate-code sdb
-      - run: pylint -d duplicate-code tests
+      - run: pylint -d duplicate-code -d invalid-name sdb
+      - run: pylint -d duplicate-code -d invalid-name tests
   #
   # Verify "pytest" runs successfully.
   #

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ script:
   #
   - yapf --diff --style google --recursive sdb
   - yapf --diff --style google --recursive tests
-  - pylint -d duplicate-code sdb
-  - pylint -d duplicate-code tests
+  - pylint -d duplicate-code -d invalid-name sdb
+  - pylint -d duplicate-code -d invalid-name tests
 
   #
   # Ensure there aren't new regressions in unit tests.

--- a/sdb/commands/zfs/dbuf.py
+++ b/sdb/commands/zfs/dbuf.py
@@ -1,0 +1,115 @@
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# pylint: disable=missing-docstring
+
+import argparse
+from typing import Iterable
+
+import drgn
+import sdb
+
+
+class Dbuf(sdb.Locator, sdb.PrettyPrinter):
+    """Iterate, filter, and pretty-print dbufs (dmu_buf_impl_t*)"""
+
+    names = ["dbuf"]
+    input_type = "dmu_buf_impl_t *"
+    output_type = "dmu_buf_impl_t *"
+
+    @classmethod
+    def _init_parser(cls, name: str) -> argparse.ArgumentParser:
+        parser = super()._init_parser(name)
+        parser.add_argument('-o',
+                            '--object',
+                            type=int,
+                            help='filter: only dbufs of this object')
+        parser.add_argument('-l',
+                            '--level',
+                            type=int,
+                            help='filter: only dbufs of this level')
+        parser.add_argument('-b',
+                            '--blkid',
+                            type=int,
+                            help='filter: only dbufs of this blkid')
+        parser.add_argument(
+            '-d',
+            '--dataset',
+            type=str,
+            help='filter: only dbufs of this dataset name (or "poolname/_MOS")')
+        parser.add_argument('-H',
+                            '--has-holds',
+                            action='store_true',
+                            help='filter: only dbufs that have nonzero holds')
+        return parser
+
+    @staticmethod
+    def DslDirName(dd: drgn.Object):
+        pname = ''
+        if dd.dd_parent:
+            pname = Dbuf.DslDirName(dd.dd_parent) + '/'
+        return pname + dd.dd_myname.string_().decode("utf-8")
+
+    @staticmethod
+    def DatasetName(ds: drgn.Object):
+        name = Dbuf.DslDirName(ds.ds_dir)
+        if not ds.ds_prev:
+            sn = ds.ds_snapname.string_().decode("utf-8")
+            if len(sn) == 0:
+                sn = '%UNKNOWN_SNAP_NAME%'
+            name += '@' + sn
+        return name
+
+    @staticmethod
+    def ObjsetName(os: drgn.Object):
+        if not os.os_dsl_dataset:
+            return '{}/_MOS'.format(
+                os.os_spa.spa_name.string_().decode("utf-8"))
+        return Dbuf.DatasetName(os.os_dsl_dataset)
+
+    def pretty_print(self, dbufs):
+        print("{:>20} {:>8} {:>4} {:>8} {:>5} {}".format(
+            "addr", "object", "lvl", "blkid", "holds", "os"))
+        for dbuf in dbufs:
+            print("{:>20} {:>8d} {:>4d} {:>8d} {:>5d} {}".format(
+                hex(dbuf), int(dbuf.db.db_object), int(dbuf.db_level),
+                int(dbuf.db_blkid), int(dbuf.db_holds.rc_count),
+                Dbuf.ObjsetName(dbuf.db_objset)))
+
+    def argfilter(self, db: drgn.Object) -> bool:
+        if self.args.object and db.db.db_object != self.args.object:
+            return False
+        if self.args.level and db.db_level != self.args.level:
+            return False
+        if self.args.blkid and db.db_blkid != self.args.blkid:
+            return False
+        if self.args.has_holds and db.db_holds.rc_count == 0:
+            return False
+        if self.args.dataset and Dbuf.ObjsetName(
+                db.db_objset) != self.args.dataset:
+            return False
+        return True
+
+    def all_dbufs(self) -> Iterable[drgn.Object]:
+        hash_map = self.prog["dbuf_hash_table"].address_of_()
+        for i in range(hash_map.hash_table_mask):
+            dbuf = hash_map.hash_table[i]
+            while dbuf:
+                yield dbuf
+                dbuf = dbuf.db_hash_next
+
+    def no_input(self) -> Iterable[drgn.Object]:
+        yield from filter(self.argfilter, self.all_dbufs())


### PR DESCRIPTION
Open to input on how to organize the objset/dataset/dsl_dir helper functions.  Should I just throw the functions in the Dbuf class, rather than trying to organize them?

examples:
```
sdb> dbuf -h
usage: dbuf [-h] [-o OBJECT] [-l LEVEL] [-b BLKID] [-d DATASET] [-H]

Iterate, filter, and pretty-print dbufs (dmu_buf_impl_t*)

optional arguments:
  -h, --help            show this help message and exit
  -o OBJECT, --object OBJECT
                        filter: only dbufs of this object
  -l LEVEL, --level LEVEL
                        filter: only dbufs of this level
  -b BLKID, --blkid BLKID
                        filter: only dbufs of this blkid
  -d DATASET, --dataset DATASET
                        filter: only dbufs of this dataset name (or
                        "poolname/_MOS")
  -H, --has-holds       filter: only dbufs that have nonzero holds

sdb> dbuf
                addr   object  lvl    blkid holds os
  0xffff8b79998e4000       11    0     1200     0 rpool/ROOT/delphix.q8ykkG9/log
  0xffff8b799d3ce5a0        0    0     1372     3 rpool/ROOT/delphix.q8ykkG9/root
  0xffff8b78d7d12438    11108    1        0     0 rpool/ROOT/delphix.q8ykkG9/root
  0xffff8b797078f950        0    0        0     1 testpool/testfs
  0xffff8b78aaf9f248        0    0      310    32 rpool/ROOT/delphix.q8ykkG9/root
  0xffff8b798bd3f3b0        0    0     5155    32 rpool/ROOT/delphix.q8ykkG9/root
  0xffff8b7969a6c438      164    0      108     0 rpool/ROOT/delphix.q8ykkG9/data
  0xffff8b798033bd88        0    0      155    17 rpool/ROOT/delphix.q8ykkG9/root
...

sdb> dbuf -o 8
                addr   object  lvl    blkid holds os
  0xffff8b7914ec10e0        8    0       57     0 rpool/ROOT/delphix.q8ykkG9/log
  0xffff8b797078f248        8    0       64     0 rpool/ROOT/delphix.q8ykkG9/log
  0xffff8b795fd5d248        8    0       34     0 rpool/ROOT/delphix.q8ykkG9/log
...

sdb> dbuf -d rpool/_MOS
                addr   object  lvl    blkid holds os
  0xffff8b7968548168      132    0        0     0 rpool/_MOS
  0xffff8b7995a85c20       55    0        0     0 rpool/_MOS
  0xffff8b798e3209d8      216    1        0     2 rpool/_MOS
  0xffff8b79989b1680       22    0        0     0 rpool/_MOS
  0xffff8b7999e9af78      216    0        2     0 rpool/_MOS
...

sdb> dbuf -d rpool/_MOS -l 1
                addr   object  lvl    blkid holds os
  0xffff8b798e3209d8      216    1        0     2 rpool/_MOS
  0xffff8b78009bf7e8      225    1        0     1 rpool/_MOS
  0xffff8b78d8e1c2d0      221    1        0     1 rpool/_MOS
  0xffff8b7912f2dd88       25    1        0     2 rpool/_MOS
  0xffff8b78d8e1d518        2    1        0     1 rpool/_MOS
  0xffff8b78009bf950      215    1        0     1 rpool/_MOS
...

sdb> dbuf | wc
(unsigned long long)3902
```