### PR TITLE
Coerce from void* is broken

### DIFF
--- a/sdb/coerce.py
+++ b/sdb/coerce.py
@@ -65,7 +65,7 @@ class Coerce(sdb.Command):
 
         # "void *" can be coerced to any pointer type
         if (obj.type_.kind is drgn.TypeKind.POINTER and
-                obj.type_.primitive is drgn.PrimitiveType.C_VOID):
+                obj.type_.type.primitive is drgn.PrimitiveType.C_VOID):
             return drgn.cast(self.type, obj)
 
         # integers can be coerced to any pointer typo


### PR DESCRIPTION
before:
```
> spa testpool | member spa_sm_logs_by_txg | address | cast void* | avl
kind: TypeKind.POINTER; primitive: None
Traceback (most recent call last):
  File "/usr/local/bin/sdb", line 11, in <module>
    load_entry_point('sdb==0.1.0', 'console_scripts', 'sdb')()
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/cli.py", line 216, in main
    repl.start_session()
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/repl.py", line 114, in start_session
    _ = self.eval_cmd(line)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/repl.py", line 87, in eval_cmd
    for obj in objs:
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/__init__.py", line 180, in invoke
    yield from execute_pipeline(prog, first_input, pipeline)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/__init__.py", line 77, in execute_pipeline
    yield from pipeline[-1].call(this_input)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/walker.py", line 51, in call
    for obj in objs:
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/__init__.py", line 77, in execute_pipeline
    yield from pipeline[-1].call(this_input)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/coerce.py", line 85, in call
    yield self.coerce(obj)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/coerce.py", line 81, in coerce
    raise TypeError("can not coerce {} to {}".format(obj.type_, self.type))
TypeError: can not coerce void * to avl_tree_t *
bash$
```
after:
```
> spa testpool | member spa_sm_logs_by_txg | address | cast void* | avl
(void *)0xffff8b78c9e101c0
(void *)0xffff8b78c9e10d80
(void *)0xffff8b78ed223100
(void *)0xffff8b78ed2235c0
(void *)0xffff8b78b61d3cc0
(void *)0xffff8b7982c28480
(void *)0xffff8b79632de080
(void *)0xffff8b78bb7e7b40
(void *)0xffff8b78ca2dc080
```