### PR TITLE
Fix pytest failure due to drgn changes

### DIFF
--- a/tests/commands/test_member.py
+++ b/tests/commands/test_member.py
@@ -47,7 +47,7 @@ def test_scalar_input():
     with pytest.raises(sdb.CommandError) as err:
         invoke(MOCK_PROGRAM, objs, line)
 
-    assert "'int' is not a structure or union" in str(err.value)
+    assert "'int' is not a structure, union, or class" in str(err.value)
 
 
 def test_member_not_found():


### PR DESCRIPTION
While upstreaming some other PR I got the following failure
from automated testing:
```
=================================== FAILURES ===================================
______________________________ test_scalar_input _______________________________

    def test_scalar_input():
        line = 'addr global_int | member int_member'
        objs = []

        with pytest.raises(sdb.CommandError) as err:
            invoke(MOCK_PROGRAM, objs, line)

>       assert "'int' is not a structure or union" in str(err.value)
E       assert "'int' is not a structure or union" in "sdb: member: 'int' is not a structure, union, or class"
E        +  where "sdb: member: 'int' is not a structure, union, or class" = str(CommandError("sdb: member: 'int' is not a structure, union, or class",))
E        +    where CommandError("sdb: member: 'int' is not a structure, union, or class",) = <ExceptionInfo CommandError tblen=5>.value
```

This was due to a recent commit in drgn:
https://github.com/osandov/drgn/commit/0df215230755ab02cccb9e966d15001705bd335b