### PR TITLE
throw sdb.CommandError rather than TypeError

### DIFF
--- a/sdb/coerce.py
+++ b/sdb/coerce.py
@@ -52,8 +52,9 @@ class Coerce(sdb.Command):
         self.type = self.prog.type(" ".join(self.args.type))
 
         if self.type.kind is not drgn.TypeKind.POINTER:
-            raise TypeError("can only coerce to pointer types, not {}".format(
-                self.type))
+            raise sdb.CommandError(
+                self.name,
+                "can only coerce to pointer types, not {}".format(self.type))
 
     def coerce(self, obj: drgn.Object) -> drgn.Object:
         """
@@ -79,7 +80,8 @@ class Coerce(sdb.Command):
         ).type_ == self.type:
             return obj.address_of_()
 
-        raise TypeError("can not coerce {} to {}".format(obj.type_, self.type))
+        raise sdb.CommandError(
+            self.name, "can not coerce {} to {}".format(obj.type_, self.type))
 
     def call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
         for obj in objs:

--- a/sdb/commands/zfs/metaslab.py
+++ b/sdb/commands/zfs/metaslab.py
@@ -177,9 +177,10 @@ class Metaslab(sdb.Locator, sdb.PrettyPrinter):
             # yield the requested metaslabs
             for i in self.args.metaslab_ids:
                 if i >= vdev.vdev_ms_count:
-                    raise TypeError(
-                        "metaslab id {} not valid; there are only {} metaslabs in vdev id {}"
-                        .format(i, vdev.vdev_ms_count, vdev.vdev_id))
+                    raise sdb.CommandError(
+                        self.name, "metaslab id {} not valid; "
+                        "there are only {} metaslabs in vdev id {}".format(
+                            i, int(vdev.vdev_ms_count), int(vdev.vdev_id)))
                 yield vdev.vdev_ms[i]
         else:
             for i in range(0, int(vdev.vdev_ms_count)):

--- a/sdb/commands/zfs/vdev.py
+++ b/sdb/commands/zfs/vdev.py
@@ -119,13 +119,11 @@ class Vdev(sdb.Locator, sdb.PrettyPrinter):
             # yield the requested top-level vdevs
             for i in self.args.vdev_ids:
                 if i >= spa.spa_root_vdev.vdev_children:
-                    raise TypeError(
+                    raise sdb.CommandError(
+                        self.name,
                         "vdev id {} not valid; there are only {} vdevs in {}".
-                        format(
-                            i,
-                            spa.spa_root_vdev.vdev_children,
-                            spa.spa_name.string_().decode("utf-8"),
-                        ))
+                        format(i, int(spa.spa_root_vdev.vdev_children),
+                               spa.spa_name.string_().decode("utf-8")))
                 yield spa.spa_root_vdev.vdev_child[i]
         else:
             yield from self.from_vdev(spa.spa_root_vdev)
@@ -133,9 +131,9 @@ class Vdev(sdb.Locator, sdb.PrettyPrinter):
     @sdb.InputHandler("vdev_t*")
     def from_vdev(self, vdev: drgn.Object) -> Iterable[drgn.Object]:
         if self.args.vdev_ids:
-            raise TypeError(
-                "when providing a vdev, specific child vdevs can not be requested"
-            )
+            raise sdb.CommandError(
+                self.name, "when providing a vdev, "
+                "specific child vdevs can not be requested")
         yield vdev
         for cid in range(0, int(vdev.vdev_children)):
             cvd = vdev.vdev_child[cid]

--- a/sdb/locator.py
+++ b/sdb/locator.py
@@ -48,7 +48,7 @@ class Locator(sdb.Command):
 
     def no_input(self) -> Iterable[drgn.Object]:
         # pylint: disable=missing-docstring
-        raise TypeError('command "{}" requires an input'.format(self.names))
+        raise sdb.CommandError(self.name, 'command requires an input')
 
     def caller(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
         """
@@ -104,9 +104,8 @@ class Locator(sdb.Command):
                 pass
 
             # error
-            raise TypeError(
-                'command "{}" does not handle input of type {}'.format(
-                    self.names, i.type_))
+            raise sdb.CommandError(
+                self.name, 'no handler for input of type {}'.format(i.type_))
         if not has_input:
             yield from self.no_input()
 

--- a/sdb/walker.py
+++ b/sdb/walker.py
@@ -50,8 +50,9 @@ class Walker(sdb.Command):
         type_ = self.prog.type(self.input_type)
         for obj in objs:
             if obj.type_ != type_:
-                raise TypeError(
-                    'command "{}" does not handle input of type {}'.format(
-                        self.names, obj.type_))
+                raise sdb.CommandError(
+                    self.name,
+                    'expected input of type {}, but received {}'.format(
+                        type_, obj.type_))
 
             yield from self.walk(obj)


### PR DESCRIPTION
Several commands throw TypeError where they should be throwing
CommandError.

Also clean up a few error messages.

Closes #47
Closes #64
Closes #65

old:
```
> vdev
 ADDR               STATE   AUX  DESCRIPTION
 ------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/bin/sdb", line 11, in <module>
    load_entry_point('sdb==0.1.0', 'console_scripts', 'sdb')()
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/cli.py", line 216, in main
    repl.start_session()
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/repl.py", line 114, in start_session
    _ = self.eval_cmd(line)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/repl.py", line 87, in eval_cmd
    for obj in objs:
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/__init__.py", line 180, in invoke
    yield from execute_pipeline(prog, first_input, pipeline)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/__init__.py", line 77, in execute_pipeline
    yield from pipeline[-1].call(this_input)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/locator.py", line 119, in call
    self.pretty_print(self.caller(objs))
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/commands/zfs/vdev.py", line 77, in pretty_print
    for vdev in vdevs:
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/locator.py", line 111, in caller
    yield from self.no_input()
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/locator.py", line 51, in no_input
    raise TypeError('command "{}" requires an input'.format(self.names))
TypeError: command "['vdev']" requires an input
delphix@mahrens-sdb2:~/sdb$ sudo sdb
sdb: could not get debugging information for:
/lib/modules/4.15.0-66-generic/kernel/net/connstat/connstat.ko (libdwfl error: No DWARF information found)
> metaslab
Traceback (most recent call last):
  File "/usr/local/bin/sdb", line 11, in <module>
    load_entry_point('sdb==0.1.0', 'console_scripts', 'sdb')()
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/cli.py", line 216, in main
    repl.start_session()
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/repl.py", line 114, in start_session
    _ = self.eval_cmd(line)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/repl.py", line 87, in eval_cmd
    for obj in objs:
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/__init__.py", line 180, in invoke
    yield from execute_pipeline(prog, first_input, pipeline)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/__init__.py", line 77, in execute_pipeline
    yield from pipeline[-1].call(this_input)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/locator.py", line 119, in call
    self.pretty_print(self.caller(objs))
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/commands/zfs/metaslab.py", line 159, in pretty_print
    for msp in metaslabs:
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/locator.py", line 111, in caller
    yield from self.no_input()
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/locator.py", line 51, in no_input
    raise TypeError('command "{}" requires an input'.format(self.names))
TypeError: command "['metaslab']" requires an input
delphix@mahrens-sdb2:~/sdb$ sudo sdb
sdb: could not get debugging information for:
/lib/modules/4.15.0-66-generic/kernel/net/connstat/connstat.ko (libdwfl error: No DWARF information found)
> spa rpool | vdev 0 | metaslab 400
Traceback (most recent call last):
  File "/usr/local/bin/sdb", line 11, in <module>
    load_entry_point('sdb==0.1.0', 'console_scripts', 'sdb')()
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/cli.py", line 216, in main
    repl.start_session()
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/repl.py", line 114, in start_session
    _ = self.eval_cmd(line)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/repl.py", line 87, in eval_cmd
    for obj in objs:
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/__init__.py", line 180, in invoke
    yield from execute_pipeline(prog, first_input, pipeline)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/__init__.py", line 77, in execute_pipeline
    yield from pipeline[-1].call(this_input)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/locator.py", line 119, in call
    self.pretty_print(self.caller(objs))
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/commands/zfs/metaslab.py", line 159, in pretty_print
    for msp in metaslabs:
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/locator.py", line 79, in caller
    yield from method(i)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/commands/zfs/metaslab.py", line 179, in from_vdev
    .format(i, vdev.vdev_ms_count, vdev.vdev_id))
TypeError: metaslab id 400 not valid; there are only (uint64_t)139 metaslabs in vdev id (uint64_t)0
delphix@mahrens-sdb2:~/sdb$ sudo sdb
sdb: could not get debugging information for:
/lib/modules/4.15.0-66-generic/kernel/net/connstat/connstat.ko (libdwfl error: No DWARF information found)
> spa rpool | vdev 5
 ADDR               STATE   AUX  DESCRIPTION
 ------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/bin/sdb", line 11, in <module>
    load_entry_point('sdb==0.1.0', 'console_scripts', 'sdb')()
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/cli.py", line 216, in main
    repl.start_session()
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/repl.py", line 114, in start_session
    _ = self.eval_cmd(line)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/repl.py", line 87, in eval_cmd
    for obj in objs:
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/__init__.py", line 180, in invoke
    yield from execute_pipeline(prog, first_input, pipeline)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/__init__.py", line 77, in execute_pipeline
    yield from pipeline[-1].call(this_input)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/locator.py", line 119, in call
    self.pretty_print(self.caller(objs))
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/commands/zfs/vdev.py", line 77, in pretty_print
    for vdev in vdevs:
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/locator.py", line 79, in caller
    yield from method(i)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/commands/zfs/vdev.py", line 124, in from_spa
    spa.spa_name.string_().decode("utf-8"),
TypeError: vdev id 5 not valid; there are only (uint64_t)1 vdevs in rpool
delphix@mahrens-sdb2:~/sdb$ sudo sdb
sdb: could not get debugging information for:
/lib/modules/4.15.0-66-generic/kernel/net/connstat/connstat.ko (libdwfl error: No DWARF information found)
> spa rpool | vdev 0 | vdev 2
 ADDR               STATE   AUX  DESCRIPTION
 ------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/bin/sdb", line 11, in <module>
    load_entry_point('sdb==0.1.0', 'console_scripts', 'sdb')()
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/cli.py", line 216, in main
    repl.start_session()
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/repl.py", line 114, in start_session
    _ = self.eval_cmd(line)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/repl.py", line 87, in eval_cmd
    for obj in objs:
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/__init__.py", line 180, in invoke
    yield from execute_pipeline(prog, first_input, pipeline)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/__init__.py", line 77, in execute_pipeline
    yield from pipeline[-1].call(this_input)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/locator.py", line 119, in call
    self.pretty_print(self.caller(objs))
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/commands/zfs/vdev.py", line 77, in pretty_print
    for vdev in vdevs:
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/locator.py", line 79, in caller
    yield from method(i)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/commands/zfs/vdev.py", line 134, in from_vdev
    "when providing a vdev, specific child vdevs can not be requested"
TypeError: when providing a vdev, specific child vdevs can not be requested
delphix@mahrens-sdb2:~/sdb$ sudo sdb
sdb: could not get debugging information for:
/lib/modules/4.15.0-66-generic/kernel/net/connstat/connstat.ko (libdwfl error: No DWARF information found)
> zfs_dbgmsg | avl
kind: TypeKind.POINTER; primitive: None
Traceback (most recent call last):
  File "/usr/local/bin/sdb", line 11, in <module>
    load_entry_point('sdb==0.1.0', 'console_scripts', 'sdb')()
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/cli.py", line 216, in main
    repl.start_session()
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/repl.py", line 114, in start_session
    _ = self.eval_cmd(line)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/repl.py", line 87, in eval_cmd
    for obj in objs:
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/__init__.py", line 180, in invoke
    yield from execute_pipeline(prog, first_input, pipeline)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/__init__.py", line 77, in execute_pipeline
    yield from pipeline[-1].call(this_input)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/walker.py", line 57, in call
    yield from self.walk(obj)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/commands/spl/avl.py", line 47, in walk
    yield from self._helper(root, offset)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/commands/spl/avl.py", line 36, in _helper
    yield from self._helper(lchild, offset)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/commands/spl/avl.py", line 36, in _helper
    yield from self._helper(lchild, offset)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/commands/spl/avl.py", line 36, in _helper
    yield from self._helper(lchild, offset)
  [Previous line repeated 987 more times]
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/commands/spl/avl.py", line 32, in _helper
    if node == drgn.NULL(self.prog, node.type_):
RecursionError: maximum recursion depth exceeded in comparison
delphix@mahrens-sdb2:~/sdb$ sudo sdb
sdb: could not get debugging information for:
/lib/modules/4.15.0-66-generic/kernel/net/connstat/connstat.ko (libdwfl error: No DWARF information found)
> spa | metaslab
The following types have walkers:
	WALKER               TYPE
	['avl']              avl_tree_t *
	['spl_list']         list_t *
Traceback (most recent call last):
  File "/usr/local/bin/sdb", line 11, in <module>
    load_entry_point('sdb==0.1.0', 'console_scripts', 'sdb')()
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/cli.py", line 216, in main
    repl.start_session()
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/repl.py", line 114, in start_session
    _ = self.eval_cmd(line)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/repl.py", line 87, in eval_cmd
    for obj in objs:
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/__init__.py", line 180, in invoke
    yield from execute_pipeline(prog, first_input, pipeline)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/__init__.py", line 77, in execute_pipeline
    yield from pipeline[-1].call(this_input)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/locator.py", line 119, in call
    self.pretty_print(self.caller(objs))
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/commands/zfs/metaslab.py", line 159, in pretty_print
    for msp in metaslabs:
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/locator.py", line 109, in caller
    self.names, i.type_))
TypeError: command "['metaslab']" does not handle input of type spa_t *
delphix@mahrens-sdb2:~/sdb$
```

new:
```
sdb> vdev
 ADDR               STATE   AUX  DESCRIPTION
 ------------------------------------------------------------
sdb: vdev: command requires an input

sdb> metaslab
sdb: metaslab: command requires an input

sdb> spa rpool | vdev 0 | metaslab 400
sdb: metaslab: metaslab id 400 not valid; there are only 139 metaslabs in vdev id 0

sdb> spa rpool | vdev 5
 ADDR               STATE   AUX  DESCRIPTION
 ------------------------------------------------------------
sdb: vdev: vdev id 5 not valid; there are only 1 vdevs in rpool

sdb> spa rpool | vdev 0 | vdev 2
 ADDR               STATE   AUX  DESCRIPTION
 ------------------------------------------------------------
sdb: vdev: when providing a vdev, specific child vdevs can not be requested

sdb> zfs_dbgmsg | avl
sdb: _: can not coerce zfs_dbgmsg_t * to avl_tree_t *

sdb> spa | metaslab
The following types have walkers:
	WALKER               TYPE
	spl_list             list_t *
	avl                  avl_tree_t *
sdb: metaslab: no handler for input of type spa_t *
```

Note: there's still some weirdness in the above errors (e.g. printing the walkers), but I wanted to keep the scope of this commit small.  `Walk` also uses TypeError, but I want to rewrite it to be more like pretty_print (see #84).