### PR TITLE
Ctrl+C should return to prompt

### DIFF
--- a/sdb/internal/repl.py
+++ b/sdb/internal/repl.py
@@ -96,6 +96,15 @@ class REPL:
         except sdb.Error as err:
             print(err.text)
             return 1
+        except KeyboardInterrupt:
+            #
+            # Interrupting commands half way through their execution
+            # (e.g. with Ctrl+c) should be allowed. Note that we
+            # print a new line for better formatting of the next
+            # prompt.
+            #
+            print()
+            return 1
         return 0
 
     def start_session(self) -> None:
@@ -105,7 +114,21 @@ class REPL:
         while True:
             try:
                 line = input(self.prompt).strip()
-            except (EOFError, KeyboardInterrupt, SystemExit):
+            except KeyboardInterrupt:
+                #
+                # Pressing Ctrl+C while in the middle of writing
+                # a command or before even typing anything should
+                # bring back a new prompt. The user should use
+                # Ctrl+d if they need to exit without typing a
+                # command.
+                #
+                # We clear out `line` and print a new line so we
+                # don't display multiple prompts within the same
+                # line.
+                #
+                line = ""
+                print()
+            except (EOFError, SystemExit):
                 print(self.closing)
                 break
 


### PR DESCRIPTION
= Motivation

There are times when a user may have entered a command that
takes a lot of time and they need to interrupt it halfway
with Ctrl+C (e.g. `dbuf`). Currently, Ctrl+C in this scenario
just crashes `sdb` and drops the user out of the session.

= Patch

This patch cleanly interrupts the running command (e.g. no
stack traces are printed) and returns to the prompt. Also,
it ensures that if Ctrl+C is pressed while writing to the
prompt we get a new prompt.

= Testing

Interrupting a running command
```
sdb> dbuf
                addr   object  lvl    blkid holds os
  0xffff9d0a6dab2708     1439    0      201     0 rpool/ROOT/delphix.wD4dDAM/data
  0xffff9d09f007e2d0    59141    0        0     0 rpool/_MOS
  0xffff9d0ae24629d8      129    0        0     0 rpool/_MOS
  0xffff9d0ae893ab40        0    0     2257     2 rpool/ROOT/delphix.wD4dDAM/root
  0xffff9d09c7a97518    57247    0        0     0 rpool/ROOT/delphix.wD4dDAM/root
  0xffff9d0a6e1aeca8        0    0     5947     8 rpool/ROOT/delphix.wD4dDAM/root
  0xffff9d0a2540fc20        0    0     1841     1 rpool/ROOT/delphix.wD4dDAM/home
  0xffff9d0a73951518    59143    0        0     0 rpool/ROOT/delphix.wD4dDAM/root
  0xffff9d0ac56f8ca8    59403    0        0     0 rpool/ROOT/delphix.wD4dDAM/root
  0xffff9d0aeee10f78     3219    0        0     0 rpool/ROOT/delphix.wD4dDAM/data
  0xffff9d0a8ae09ab8        0    0     1956     1 rpool/ROOT/delphix.wD4dDAM/root
^C
sdb>
```

Hitting Ctrl+C a bunch of times with no input:
```
sdb>
sdb>
sdb>
```

Hitting Ctrl+C with some input:
```
sdb> address spa_namespace_avl | walk | sp
sdb>
```

= Github Issue Tracker Automation

Closes #73