### PR TITLE
Handling Command Failures - Part 1

### DIFF
--- a/sdb/internal/repl.py
+++ b/sdb/internal/repl.py
@@ -19,6 +19,7 @@
 import atexit
 import os
 import readline
+import traceback
 
 import sdb
 
@@ -79,6 +80,7 @@ class REPL:
             1 for error
             2 for incorrect arguments passed
         """
+        # pylint: disable=broad-except
         try:
             objs = sdb.invoke(self.target, [], input_)
             if not objs:
@@ -104,6 +106,37 @@ class REPL:
             # prompt.
             #
             print()
+            return 1
+        except Exception:
+            #
+            # Ideally it would be great if all commands had no issues and
+            # would take care of all their possible edge case. That is
+            # something that we should strive for and ask in code reviews
+            # when introducing commands. Looking into the long-term though
+            # if SDB commands/modules are to be decoupled from the SDB repo,
+            # it can be harder to have control over the quality of the
+            # commands imported by SDB during the runtime.
+            #
+            # Catching all exceptions from the REPL may be a bit ugly as a
+            # programming practice in general. That said in this case, not
+            # catching these errors leads to the worst outcome in terms of
+            # user-experience that you can get from SDB - getting dropped
+            # out of SDB with a non-friendly error message. Furthermore,
+            # given that there is no state maintained in the REPL between
+            # commands, attempting to recover after a command error is not
+            # that bad and most probably won't lead to any problems in
+            # future commands issued within the same session.
+            #
+            print("sdb encountered an internal error due to a bug. Here's the")
+            print("information you need to file the bug:")
+            print("----------------------------------------------------------")
+            print("Target Info:")
+            print(f"\t{self.target.flags}")
+            print(f"\t{self.target.platform}")
+            print()
+            traceback.print_exc()
+            print("----------------------------------------------------------")
+            print("Link: https://github.com/delphix/sdb/issues/new")
             return 1
         return 0
 


### PR DESCRIPTION
= Summary

Do not break out of a session when a command crashes or a
bug shows up in the SDB infrastructure. Prompt the user
to file a bug and keep the session instead. State is not
retained between commands issued thus this is safe to do
for now and provides a more user-friendly experience.

= Testing

```
sdb> echo 1234 | cast dnode_t * | pp
sdb encountered an internal error due to a bug. Here's the
information you need to file the bug:
----------------------------------------------------------
Target Info:
	ProgramFlags.IS_LIVE|IS_LINUX_KERNEL
	Platform(<Architecture.X86_64: 1>, <PlatformFlags.IS_LITTLE_ENDIAN|IS_64_BIT: 3>)

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/repl.py", line 88, in eval_cmd
    for obj in objs:
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/__init__.py", line 182, in invoke
    execute_pipeline_term(prog, first_input, pipeline)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/__init__.py", line 103, in execute_pipeline_term
    pipeline[-1].call(this_input)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/commands/pretty_print.py", line 48, in call
    self.names, i.type_))
TypeError: command "['pretty_print', 'pp']" does not handle input of type dnode_t *
----------------------------------------------------------
Link: https://github.com/delphix/sdb/issues/new
```

= Github Issue Tracker Automation

Closes #87