### PR TITLE
walk should use sdb.CommandError

### DIFF
--- a/sdb/locator.py
+++ b/sdb/locator.py
@@ -100,7 +100,7 @@ class Locator(sdb.Command):
                 for obj in Walk(self.prog).call([i]):
                     yield drgn.cast(out_type, obj)
                 continue
-            except TypeError:
+            except sdb.CommandError:
                 pass
 
             # error


### PR DESCRIPTION
old:
```
sdb> spa | walk
The following types have walkers:
	WALKER               TYPE
	zfs_btree            zfs_btree_t *
	avl                  avl_tree_t *
	spl_list             list_t *
sdb encountered an internal error due to a bug. Here's the
information you need to file the bug:
----------------------------------------------------------
Target Info:
	ProgramFlags.IS_LIVE|IS_LINUX_KERNEL
	Platform(<Architecture.X86_64: 1>, <PlatformFlags.IS_LITTLE_ENDIAN|IS_64_BIT: 3>)

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/repl.py", line 89, in eval_cmd
    for obj in objs:
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/__init__.py", line 180, in invoke
    yield from execute_pipeline(prog, first_input, pipeline)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/__init__.py", line 77, in execute_pipeline
    yield from pipeline[-1].call(this_input)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/commands/walk.py", line 52, in call
    i.type_))
TypeError: no walker found for input of type spa_t *
----------------------------------------------------------
Link: https://github.com/delphix/sdb/issues/new
```

new:
```
sdb> spa | walk
sdb: walk: no walker found for input of type spa_t *
The following types have walkers:
	WALKER               TYPE
	spl_list             list_t *
	avl                  avl_tree_t *
	zfs_btree            zfs_btree_t *

sdb> walk
The following types have walkers:
	WALKER               TYPE
	avl                  avl_tree_t *
	spl_list             list_t *
	zfs_btree            zfs_btree_t *
```