### PR TITLE
Run Actions on a regular basis

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,9 @@
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron:  '0 0 * * *'
+
 jobs:
   #
   # Verify the build and installation of SDB.


### PR DESCRIPTION
Currently our tests are not entirely reproducible, since we don't pin
our dependencies to specific versions. Thus, frequently we'll open a
pull request, only to realize that a depdency has changed, and a new
test regression was silently introduced.

To help us notice these regressions sooner, this change is augmenting
our tests to run on a daily basis. This way, we'll continually test with
new versions of our dependencies, which should help us detect when
regressions are introduced, and allow us to fix the issue before the
test failure cascades into an unrelated pull request.