### PR TITLE
sdb needs to evaluate its own type equality

### DIFF
--- a/sdb/__init__.py
+++ b/sdb/__init__.py
@@ -33,7 +33,8 @@ from sdb.error import (Error, CommandNotFoundError, CommandError,
                        CommandArgumentsError, CommandEvalSyntaxError)
 from sdb.target import (create_object, get_object, get_prog, get_typed_null,
                         get_type, get_pointer_type, get_target_flags,
-                        get_symbol)
+                        get_symbol, type_canonical_name, type_canonicalize,
+                        type_canonicalize_name, type_equals)
 from sdb.command import (Address, Cast, Command, InputHandler, Locator,
                          PrettyPrinter, Walk, Walker, get_registered_commands)
 from sdb.pipeline import execute_pipeline, get_first_type, invoke


### PR DESCRIPTION
The drgn type equality operator boils the ocean in an attempt to
evaluate deep type equality.

We just need to know, "is this a foo_t*", without regard for which
source .c file defined the foo_t.

Therefore, we can assume that types with the same name are equal.