### PR TITLE
minor style cleanup

### DIFF
--- a/sdb/commands/zfs/internal/__init__.py
+++ b/sdb/commands/zfs/internal/__init__.py
@@ -15,15 +15,14 @@
 #
 
 # pylint: disable=missing-docstring
-# pylint: disable=unnecessary-lambda
 
 import os
-from typing import Callable
+from typing import List
 
 import drgn
 
 
-def enum_lookup(prog, enum_type_name, value):
+def enum_lookup(prog: drgn.Program, enum_type_name: str, value: int):
     """return a string which is the short name of the enum value
     (truncating off the common prefix) """
     fields = prog.type(enum_type_name).type.enumerators
@@ -31,7 +30,7 @@ def enum_lookup(prog, enum_type_name, value):
     return fields[value][0][prefix.rfind("_") + 1:]
 
 
-def print_histogram(histogram, size, offset):
+def print_histogram(histogram: List[int], size: int, offset: int) -> None:
     max_data = 0
     maxidx = 0
     minidx = size - 1
@@ -51,7 +50,7 @@ def print_histogram(histogram, size, offset):
               (i + offset, histogram[i], "*" * int(histogram[i])))
 
 
-def nicenum(num, suffix="B"):
+def nicenum(num: int, suffix: str = "B") -> str:
     for unit in ["", "K", "M", "G", "T", "P", "E", "Z"]:
         if num < 1024:
             return "{}{}{}".format(int(num), unit, suffix)
@@ -59,23 +58,27 @@ def nicenum(num, suffix="B"):
     return "{}{}{}".format(int(num), "Y", suffix)
 
 
-P2PHASE: Callable[[drgn.Object, int], drgn.Object] = lambda x, align: ((x) & (
-    (align) - 1))
-BF64_DECODE: Callable[[drgn.Object, int, int], int] = lambda x, low, len: int(
-    P2PHASE(x >> low, 1 << len))
-BF64_GET: Callable[[drgn.Object, int, int],
-                   int] = lambda x, low, len: BF64_DECODE(x, low, len)
+def P2PHASE(x: drgn.Object, align: int) -> int:
+    return int(x & (align - 1))
 
 
-def WEIGHT_IS_SPACEBASED(weight):  # pylint: disable=invalid-name
+def BF64_DECODE(x: drgn.Object, low: int, length: int) -> int:
+    return int(P2PHASE(x >> low, 1 << length))
+
+
+def BF64_GET(x: drgn.Object, low: int, length: int) -> int:
+    return BF64_DECODE(x, low, length)
+
+
+def WEIGHT_IS_SPACEBASED(weight: int) -> bool:
     return weight == 0 or BF64_GET(weight, 60, 1)
 
 
-def WEIGHT_GET_INDEX(weight):  # pylint: disable=invalid-name
+def WEIGHT_GET_INDEX(weight: int) -> int:
     return BF64_GET((weight), 54, 6)
 
 
-def WEIGHT_GET_COUNT(weight):  # pylint: disable=invalid-name
+def WEIGHT_GET_COUNT(weight: int) -> int:
     return BF64_GET((weight), 0, 54)
 
 

--- a/sdb/locator.py
+++ b/sdb/locator.py
@@ -120,13 +120,16 @@ class Locator(sdb.Command):
             yield from self.caller(objs)
 
 
-# pylint: disable=invalid-name
 T = TypeVar("T", bound=Locator)
 IH = Callable[[T, drgn.Object], Iterable[drgn.Object]]
 
 
 def InputHandler(typename: str) -> Callable[[IH[T]], IH[T]]:
-    # pylint: disable=invalid-name,missing-docstring
+    """
+    This is a decorator which should be applied to methods of subclasses of
+    Locator. The decorator causes this method to be called when the pipeline
+    passes an object of the specified type to this Locator.
+    """
 
     def decorator(func: IH[T]) -> IH[T]:
         func.input_typename_handled = typename  # type: ignore


### PR DESCRIPTION
We now ignore all invalid-name checks, so we don't need to annotate
them.

Add type info to `zfs/internal/__init__.py`

Use `def` rather than `lambda`.

Tested with `metaslab`, after fixing #98.