### PR TITLE
add multilist walker

### DIFF
--- a/sdb/commands/spl/multilist.py
+++ b/sdb/commands/spl/multilist.py
@@ -1,0 +1,34 @@
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# pylint: disable=missing-docstring
+
+from typing import Iterable
+
+import drgn
+import sdb
+from sdb.commands.spl.spl_list import SPLList
+
+
+class MultiList(sdb.Walker):
+    names = ["multilist"]
+    input_type = "multilist_t *"
+
+    def walk(self, obj: drgn.Object) -> Iterable[drgn.Object]:
+        for i in range(obj.ml_num_sublists):
+            sublist = obj.ml_sublists[i].mls_list.address_of_()
+            yield from sdb.execute_pipeline(self.prog, [sublist],
+                                            [SPLList(self.prog)])


### PR DESCRIPTION
Closes #31

```
sdb> addr arc_mru | member [0].arcs_list[1] | type
multilist_t *

sdb> addr arc_mru | member [0].arcs_list[1] | walk | head
(void *)0xffff9b9b193058f8
(void *)0xffff9b9b77b1bb88
(void *)0xffff9b9b37cb9668
(void *)0xffff9b9b51aba148
(void *)0xffff9b9b88a40148
(void *)0xffff9b9ce520a8f8
(void *)0xffff9b9b43658000
(void *)0xffff9b9b127aaa40
(void *)0xffff9b9b51abab88
(void *)0xffff9b9cd56d5668
```