### PR TITLE
Fix commands that define non-generator call()

### DIFF
--- a/sdb/__init__.py
+++ b/sdb/__init__.py
@@ -73,25 +73,8 @@ def execute_pipeline(first_input: Iterable[drgn.Object],
     yield from pipeline[-1].massage_input_and_call(this_input)
 
 
-def execute_pipeline_term(first_input: Iterable[drgn.Object],
-                          pipeline: List["sdb.Command"]) -> None:
-    """
-    This function is very similar to execute_pipeline, with the
-    exception that it doesn't yield any results. This function should be
-    used (rather than execute_pipeline) when the last sdb.Command in the
-    pipeline doesn't yield any results.
-    """
-
-    if len(pipeline) == 1:
-        this_input = first_input
-    else:
-        this_input = execute_pipeline(first_input, pipeline[:-1])
-
-    pipeline[-1].massage_input_and_call(this_input)
-
-
 def invoke(myprog: drgn.Program, first_input: Iterable[drgn.Object],
-           line: str) -> Optional[Iterable[drgn.Object]]:
+           line: str) -> Iterable[drgn.Object]:
     """
     This function intends to integrate directly with the SDB REPL, such
     that the REPL will pass in the user-specified line, and this
@@ -165,10 +148,7 @@ def invoke(myprog: drgn.Program, first_input: Iterable[drgn.Object],
         sys.stdout = shell_proc.stdin  # type: ignore
 
     try:
-        if pipeline[-1].ispipeable:
-            yield from execute_pipeline(first_input, pipeline)
-        else:
-            execute_pipeline_term(first_input, pipeline)
+        yield from execute_pipeline(first_input, pipeline)
 
         if shell_cmd is not None:
             shell_proc.stdin.flush()

--- a/sdb/internal/repl.py
+++ b/sdb/internal/repl.py
@@ -82,11 +82,7 @@ class REPL:
         """
         # pylint: disable=broad-except
         try:
-            objs = sdb.invoke(self.target, [], input_)
-            if not objs:
-                return 0
-
-            for obj in objs:
+            for obj in sdb.invoke(self.target, [], input_):
                 print(obj)
         except sdb.CommandArgumentsError:
             #


### PR DESCRIPTION
Dealing with functions that may or may not be generators is tricky.
The call() method for subclasses of Command is one example.
Unfortunately, #100 broke non-generator Commands like `pp` and `help`.
The specific problem is twofold:

1. changing execute_pipeline_term() to call a generator
(massage_input_and_call), which doesn't work (you have to `yield from`
or iterate over a generator).  The solution is to iterate this
generator, even when we expect it not yield anything.

2. massage_input_and_call() `yield from` a non-generator function
(self.call).  The solution is to only `yield from` `self.call` if it
returns something.