### PR TITLE
Auto-generate help message based on inspected types

### DIFF
--- a/sdb/command.py
+++ b/sdb/command.py
@@ -95,6 +95,7 @@ class Command:
         command class that it's called on. The docstring and parser for
         the class is used to populate the contents of the message.
         """
+        # pylint: disable=too-many-branches
         parser = cls._init_parser(name)
 
         print("SUMMARY")
@@ -112,6 +113,50 @@ class Command:
             print("ALIASES")
             print("    {}".format(", ".join(cls.names)))
             print()
+
+        if cls.input_type is not None:
+            print("INPUT TYPE")
+            print(f"    This command primarily accepts "
+                  f"inputs of type {cls.input_type}.")
+            print()
+
+        if issubclass(cls, sdb.PrettyPrinter):
+            print("PRETTY PRINTER")
+            print(f"    This is a PrettyPrinter for {cls.input_type}.")
+            print(f"    If prints a human-readable decoding of the object.")
+            print(f"    For the raw object contents, pipe the "
+                  f"output to 'echo'.")
+            print()
+
+        if issubclass(cls, sdb.Walker):
+            print("PRETTY PRINTER")
+            print(f"    This is a Walker for {cls.input_type}.  "
+                  "See 'help walk'.")
+            print()
+
+        if issubclass(cls, sdb.Locator):
+            # pylint: disable=no-member
+            print("LOCATOR")
+            print(f"    This is a Locator for {cls.output_type}.")
+            print(f"    It finds objects of this type and "
+                  f"outputs or pretty-prints them.")
+            print(f"    It accepts any Walkable type (run 'walk' for a list).")
+            if cls.no_input != sdb.Locator.no_input:
+                print(f"    All objects of type {cls.output_type} "
+                      f"can be found by ")
+                print(f"    running '{name}' as the first "
+                      f"command in the pipeline.")
+            types = list()
+            for (_, method) in inspect.getmembers(cls, inspect.isroutine):
+                if hasattr(method, "input_typename_handled"):
+                    types.append(method.input_typename_handled)
+            if len(types) != 0:
+                print("    The following types are also accepted:")
+                for type_name in types:
+                    print(f"        {type_name}")
+                print(f"    Objects of type {cls.output_type} "
+                      f"which are associated with the ")
+                print(f"    input object will be located.")
 
         #
         # If the class doesn't have a docstring, "inspect.getdoc" will

--- a/sdb/commands/zfs/range_tree.py
+++ b/sdb/commands/zfs/range_tree.py
@@ -64,6 +64,13 @@ class RangeTree(sdb.PrettyPrinter):
 
 
 class RangeSeg(sdb.Locator):
+    """
+    Locate the range seg's associated with a range tree.
+
+    Given a 'range_tree_t*', locate the range_seg's assocated with it.
+    These may be type range_seg32_t*, range_seg64_t*, or range_seg_gap_t*,
+    depending on what kind of range_tree_t this is.
+    """
     names = ['range_seg']
 
     #pylint: disable=no-self-use


### PR DESCRIPTION
We can make it easier to discover the features of various commands by
having the "help" message include information that we can discover
programmatically by inspecting the Command subclass.  Specifically:

1. Its input_type
2. Whether it's a PrettyPrinter
3. Whether it's a Walker
4. If it's a Locator, and what types it can locate based on

e.g.:

```
sdb> help spa
SUMMARY
    spa [-h] [-v] [-m] [-H] [-w] [poolnames [poolnames ...]]

    positional arguments:
      poolnames

    optional arguments:
      -h, --help       show this help message and exit
      -v, --vdevs      vdevs flag
      -m, --metaslab   metaslab flag
      -H, --histogram  histogram flag
      -w, --weight     weight flag

    If this command is used to end a pipeline, it will print a human-
    readable decoding of the 'spa_t *' objects. For the 'raw' object
    contents, pipe the output of this command into 'echo'.

    This command accepts inputs of type 'void *', and 'spa_t', which
    will be converted to 'spa_t *'.

    This is a Locator for spa_t *.  It finds objects of this type and
    outputs or pretty-prints them.  It accepts any Walkable type (run
    'walk' for a list). This command can be used to start a pipeline,
    in which case it will consume no objects as input; instead it will
    locate all objects of type 'spa_t *', and emit them as output.

sdb> help avl
SUMMARY
    avl [-h]

    walk avl tree

    optional arguments:
      -h, --help  show this help message and exit

    This is a Walker for avl_tree_t *. See 'help walk'.

    This command accepts inputs of type 'void *', and 'avl_tree_t',
    which will be converted to 'avl_tree_t *'.


sdb> help dbuf
SUMMARY
    dbuf [-h] [-o OBJECT] [-l LEVEL] [-b BLKID] [-d DATASET] [-H]

    Iterate, filter, and pretty-print dbufs (dmu_buf_impl_t*)

    optional arguments:
      -h, --help            show this help message and exit
      -o OBJECT, --object OBJECT
                            filter: only dbufs of this object
      -l LEVEL, --level LEVEL
                            filter: only dbufs of this level
      -b BLKID, --blkid BLKID
                            filter: only dbufs of this blkid
      -d DATASET, --dataset DATASET
                            filter: only dbufs of this dataset name (or
                            "poolname/_MOS")
      -H, --has-holds       filter: only dbufs that have nonzero holds

    If this command is used to end a pipeline, it will print a human-
    readable decoding of the 'dmu_buf_impl_t *' objects. For the 'raw'
    object contents, pipe the output of this command into 'echo'.

    This command accepts inputs of type 'void *', and
    'dmu_buf_impl_t', which will be converted to 'dmu_buf_impl_t *'.

    This is a Locator for dmu_buf_impl_t *.  It finds objects of this
    type and outputs or pretty-prints them.  It accepts any Walkable
    type (run 'walk' for a list). This command can be used to start a
    pipeline, in which case it will consume no objects as input;
    instead it will locate all objects of type 'dmu_buf_impl_t *', and
    emit them as output. Input of the following types is also
    accepted, in which case the objects of type dmu_buf_impl_t * which
    are associated with them will be located:
        dnode_t*


sdb> help vdev
SUMMARY
    vdev [-h] [-m] [-H] [-w] [vdev_ids [vdev_ids ...]]

    positional arguments:
      vdev_ids

    optional arguments:
      -h, --help       show this help message and exit
      -m, --metaslab   metaslab flag
      -H, --histogram  histogram flag
      -w, --weight     weight flag

    If this command is used to end a pipeline, it will print a human-
    readable decoding of the 'vdev_t *' objects. For the 'raw' object
    contents, pipe the output of this command into 'echo'.

    This command accepts inputs of type 'void *', and 'vdev_t', which
    will be converted to 'vdev_t *'.

    This is a Locator for vdev_t *.  It finds objects of this type and
    outputs or pretty-prints them.  It accepts any Walkable type (run
    'walk' for a list). Input of the following types is also accepted,
    in which case the objects of type vdev_t * which are associated
    with them will be located:
        spa_t*
        vdev_t*

sdb> help pp
SUMMARY
    pp [-h]

    optional arguments:
      -h, --help  show this help message and exit

ALIASES
    pretty_print, pp

sdb> help walk
SUMMARY
    walk [-h]

    Dispatch the appropriate walker based on the type of input

    optional arguments:
      -h, --help  show this help message and exit

DESCRIPTION
    This command can be used to walk data structures when
    a specific walker for them already exists. There are
    two scenarios when this command is preferable to using
    a specific walker:
    [1] When objects of different types are passed at once
        through a pipe, this walker can dispatch the
        appropriate walker for each of them so the user
        won't need to care about the underlying data
        structure implementations.
    [2] Commands that depend on a data structure being
        traversed can use this command, to reduce the
        lines of code changed when the underlying data
        structure chages.

    For a list of walkers, run 'walk' with no input.

EXAMPLES

    sdb> addr spa_namespace_avl | walk
    (void *)0xffff9d0adbe2c000
    (void *)0xffff9d0a2dd28000
    (void *)0xffff9d0ae5040000
    (void *)0xffff9d0a2bdb0000

sdb> help range_seg
SUMMARY
    range_seg [-h]

    Locate the range seg's associated with a range tree.

    optional arguments:
      -h, --help  show this help message and exit

    This is a Locator for None.  It finds objects of this type and
    outputs or pretty-prints them.  It accepts any Walkable type (run
    'walk' for a list). Input of the following types is also accepted,
    in which case the objects of type None which are associated with
    them will be located:
        range_tree_t *

Given a 'range_tree_t*', locate the range_seg's assocated with it.
These may be type range_seg32_t*, range_seg64_t*, or range_seg_gap_t*,
depending on what kind of range_tree_t this is.

sdb>
```