### PR TITLE
range_tree Locator / PrettyPrinter

### DIFF
--- a/sdb/command.py
+++ b/sdb/command.py
@@ -449,7 +449,7 @@ class Locator(Command):
     they find. There is some logic here to support that workflow.
     """
 
-    output_type: str = ""
+    output_type: Optional[str] = None
 
     def no_input(self) -> Iterable[drgn.Object]:
         # pylint: disable=missing-docstring
@@ -461,7 +461,9 @@ class Locator(Command):
         based on the type of the input we receive.
         """
 
-        out_type = target.get_type(self.output_type)
+        out_type = None
+        if self.output_type is not None:
+            out_type = target.get_type(self.output_type)
         has_input = False
         for i in objs:
             has_input = True
@@ -493,13 +495,14 @@ class Locator(Command):
                 continue
 
             # try walkers
-            try:
-                # pylint: disable=protected-access
-                for obj in Walk()._call([i]):
-                    yield drgn.cast(out_type, obj)
-                continue
-            except CommandError:
-                pass
+            if out_type is not None:
+                try:
+                    # pylint: disable=protected-access
+                    for obj in Walk()._call([i]):
+                        yield drgn.cast(out_type, obj)
+                    continue
+                except CommandError:
+                    pass
 
             # error
             raise CommandError(

--- a/sdb/commands/zfs/range_tree.py
+++ b/sdb/commands/zfs/range_tree.py
@@ -1,0 +1,80 @@
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# pylint: disable=missing-docstring
+
+from typing import Iterable
+
+import drgn
+import sdb
+from sdb.commands.zfs.btree import Btree
+from sdb.command import Cast
+
+
+class RangeTree(sdb.PrettyPrinter):
+    names = ['range_tree']
+    input_type = 'range_tree_t *'
+
+    def pretty_print(self, objs: Iterable[drgn.Object]) -> None:
+
+        # RangeTreeSeg is a Command, and it's like a pretty-printer for
+        # range_seg*_t's, but since it has no `names`, it can't be invoked from
+        # the command line. The reason is that range_seg*_t's specify their
+        # ranges relative to rt_start/rt_shift, which are not accessible from
+        # the range_seg*_t. Therefore, they can only be pretty-printed as part
+        # of a range_tree_t*, from the range_tree pretty-printer.
+        class RangeTreeSeg(sdb.Command):
+
+            def __init__(self, rt: drgn.Object):
+                super().__init__()
+                self.rt = rt
+
+            def _call(self, objs: Iterable[drgn.Object]) -> None:
+                for seg in objs:
+                    start = (
+                        seg.rs_start << self.rt.rt_shift) + self.rt.rt_start
+                    end = (seg.rs_end << self.rt.rt_shift) + self.rt.rt_start
+                    if hasattr(self.rt, 'rs_fill'):
+                        fill = seg.rs_fill << self.rt.rt_shift
+                        print(f"    [{hex(start)} {hex(end)}) "
+                              f"(length {hex(end - start)}) "
+                              f"(fill {hex(fill)})")
+                    else:
+                        print(f"    [{hex(start)} {hex(end)}) "
+                              f"(length {hex(end - start)})")
+
+        for rt in objs:
+            print(f"{hex(rt)}: range tree of {int(rt.rt_root.bt_num_elems)} "
+                  f"entries, {int(rt.rt_space)} bytes")
+            for _ in sdb.execute_pipeline([rt], [RangeSeg(), RangeTreeSeg(rt)]):
+                pass
+
+
+class RangeSeg(sdb.Locator):
+    names = ['range_seg']
+
+    #pylint: disable=no-self-use
+    @sdb.InputHandler('range_tree_t *')
+    def from_range_tree(self, rt: drgn.Object) -> Iterable[drgn.Object]:
+        enum_dict = dict(sdb.get_type('enum range_seg_type').enumerators)
+        range_seg_type_to_type = {
+            enum_dict['RANGE_SEG32']: 'range_seg32_t*',
+            enum_dict['RANGE_SEG64']: 'range_seg64_t*',
+            enum_dict['RANGE_SEG_GAP']: 'range_seg_gap_t*',
+        }
+        seg_type_name = range_seg_type_to_type[int(rt.rt_type)]
+        yield from sdb.execute_pipeline([rt.rt_root.address_of_()],
+                                        [Btree(), Cast(seg_type_name)])


### PR DESCRIPTION
The tricky thing about this is that the Locator that finds range_seg's
given a range_tree_t* produces different types, depending on
range_tree_t:rt_type (i.e. 32, 64, or gap).  I added code to handle
Locators with no defined output_type to handle this.

An additional complication is that `range_seg*_t`'s specify their ranges
relative to `rt_start`/`rt_shift`, which are not accessible from the
`range_seg*_t`.  Therefore, there is no accessible pretty-printer for
range seg's.  They can only be pretty-printed as part of a
range_tree_t*, from the range_tree pretty-printer.

```
sdb> spa rpool | vdev 0 | metaslab  | filter obj.ms_loaded == 1 | head 1 | member ms_allocatable | range_tree !head
0xffff9b9d13439800: range tree of 100 entries, 324663808 bytes
    [0x7a00 0x7c00) (length 0x200)
    [0x8400 0x8800) (length 0x400)
    [0x8c00 0x8e00) (length 0x200)
    [0x9000 0x9400) (length 0x400)
    [0x9600 0x9c00) (length 0x600)
    [0xa800 0xba00) (length 0x1200)
    [0xc000 0xd200) (length 0x1200)
    [0xe000 0xee00) (length 0xe00)
    [0xfc00 0x13600) (length 0x3a00)

sdb> spa rpool | vdev 0 | metaslab  | filter obj.ms_loaded == 1 | head 1 | member ms_allocatable | range_seg | head 3
*(range_seg32_t *)0xffff9b9cd4301010 = {
	.rs_start = (uint32_t)61,
	.rs_end = (uint32_t)62,
}
*(range_seg32_t *)0xffff9b9cd4301018 = {
	.rs_start = (uint32_t)66,
	.rs_end = (uint32_t)68,
}
*(range_seg32_t *)0xffff9b9cd4301020 = {
	.rs_start = (uint32_t)70,
	.rs_end = (uint32_t)71,
}
```