### PR TITLE
history command

### DIFF
--- a/sdb/commands/history.py
+++ b/sdb/commands/history.py
@@ -1,0 +1,48 @@
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# pylint: disable=missing-docstring
+
+import readline
+import argparse
+from typing import Iterable
+
+import drgn
+import sdb
+
+
+class History(sdb.Command):
+    """
+    Display command history.
+    """
+    # pylint: disable=too-few-public-methods
+
+    names = ["history"]
+
+    @classmethod
+    def _init_parser(cls, name: str) -> argparse.ArgumentParser:
+        parser = super()._init_parser(name)
+        parser.add_argument("count", nargs="?", type=int)
+        return parser
+
+    def call(self, objs: Iterable[drgn.Object]) -> None:
+        stop = readline.get_current_history_length() + 1
+        if self.args.count is not None:
+            start = stop - self.args.count
+        else:
+            start = 1
+        for i in range(start, stop):
+            print(f"{i:5}  {readline.get_history_item(i)}")


### PR DESCRIPTION
```
sdb> history ! tail
  596  addr init_task ! task_struct
  597  spa !wc
  598  spa | echo !wc
  599  spa | echo !less
  600  addr init_task ! task_struct
  601  spa rpool | vdev 0 | metaslab  | filter obj.ms_loaded == 1 | member ms_allocatable | range_seg
  602  spa rpool | vdev 0 | metaslab  | filter obj.ms_loaded == 1 | member ms_allocatable | range_tree
  603  history
  604  history !tail

sdb> history 10
  602  spa rpool | vdev 0 | metaslab  | filter obj.ms_loaded == 1 | member ms_allocatable | range_tree
  603  history
  604  history !tail
  605  history
  606  history!tail
  607  history
  608  ls
  609  history
  610  history 5
  611  history 10

sdb> help history
SUMMARY
    history [-h] [count]

    Display command history.

    positional arguments:
      count

    optional arguments:
      -h, --help  show this help message and exit

```

Future work: `!1234` to re-run the specified command from the history.