### PR TITLE
Disable python bindings for libkdumpfile temporarily

### DIFF
--- a/.github/scripts/install-libkdumpfile.sh
+++ b/.github/scripts/install-libkdumpfile.sh
@@ -10,7 +10,7 @@ git clone https://github.com/ptesarik/libkdumpfile.git
 
 cd libkdumpfile
 autoreconf -fi
-./configure --with-python=$(which python3)
+./configure --with-python=no
 make
 sudo make install
 cd -


### PR DESCRIPTION
Due to issue #160 introduced by recent changes in libkdumpfile
our nightly and PR automation have been failing because the
library can't compile. Until the issue is resolved in the library
itself or on our side (by creating a proper environment for the
github action) we disable the compilation of the Python bindings
of the library. The impact is almost non-existent as these
bindings are not used in any way by SDB nor DRGN.
