### PR TITLE
Fix mock test failures introduced by latest drgn changes

### DIFF
--- a/sdb/commands/zfs/arc.py
+++ b/sdb/commands/zfs/arc.py
@@ -29,9 +29,7 @@ class ARCStats(sdb.Locator, sdb.PrettyPrinter):
 
     @staticmethod
     def print_stats(obj: drgn.Object) -> None:
-        names = [
-            tuple_[1] for tuple_ in sdb.get_type('struct arc_stats').members
-        ]
+        names = [memb.name for memb in sdb.get_type('struct arc_stats').members]
 
         for name in names:
             print("{:32} = {}".format(name, int(obj.member_(name).value.ui64)))

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -44,8 +44,8 @@ def create_struct_type(name: str, member_names: List[str],
     struct_size, bit_offset = 0, 0
     member_list = []
     for member_name, type_ in zip(member_names, member_types):
-        member_tuple = (type_, member_name, bit_offset, 0)
-        member_list.append(member_tuple)
+        member_type = drgn.TypeMember(type_, member_name, bit_offset, 0)
+        member_list.append(member_type)
         if type_.kind == drgn.TypeKind.ARRAY:
             bit_offset += 8 * type_.length * type_.type.size
             struct_size += type_.length * type_.type.size


### PR DESCRIPTION
The respective drgn flag day commit is the following:
```
commit 26ef465007e9448056496bea74816f45f8db23a8
Author: Omar Sandoval <osandov@osandov.com>
Date:   Wed Feb 12 12:04:36 2020 -0800

    libdrgn/python: add proper type for members and parameters

    This continues the conversion from the last commit. Members and
    parameters are basically the same, so we can do them together. Unlike
    enumerators, these don't make sense to unpack or access as sequences.
```
