### PR TITLE
Stacks should be a pretty printer and a locator

### DIFF
--- a/tests/integration/data/regression_output/linux/echo 0xffffa089669edc00 | stack
+++ b/tests/integration/data/regression_output/linux/echo 0xffffa089669edc00 | stack
@@ -1,0 +1,13 @@
+TASK_STRUCT        STATE             COUNT
+==========================================
+0xffffa089669edc00 INTERRUPTIBLE         1
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_hrtimeout_range_clock+0x181
+                  schedule_hrtimeout_range+0x13
+                  ep_poll+0x258
+                  do_epoll_wait+0xb0
+                  __x64_sys_epoll_wait+0x1e
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+

--- a/tests/integration/data/regression_output/linux/stacks -m bogus | count
+++ b/tests/integration/data/regression_output/linux/stacks -m bogus | count
@@ -1,0 +1,1 @@
+sdb: stacks: module 'bogus' doesn't exist or isn't currently loaded

--- a/tests/integration/data/regression_output/linux/stacks -m zfs -c zthr_procedure
+++ b/tests/integration/data/regression_output/linux/stacks -m zfs -c zthr_procedure
@@ -1,0 +1,25 @@
+TASK_STRUCT        STATE             COUNT
+==========================================
+0xffffa0895684c500 INTERRUPTIBLE        13
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  cv_wait_common+0x11f
+                  __cv_wait_sig+0x15
+                  zthr_procedure+0x51
+                  thread_generic_wrapper+0x74
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa08956849700 INTERRUPTIBLE         1
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_hrtimeout_range_clock+0xb9
+                  schedule_hrtimeout_range+0x13
+                  __cv_timedwait_hires+0x11b
+                  cv_timedwait_hires_common+0x4b
+                  cv_timedwait_sig_hires+0x14
+                  zthr_procedure+0xa4
+                  thread_generic_wrapper+0x74
+                  kthread+0x121
+                  ret_from_fork+0x1f
+

--- a/tests/integration/data/regression_output/linux/stacks -m zfs | count
+++ b/tests/integration/data/regression_output/linux/stacks -m zfs | count
@@ -1,0 +1,1 @@
+(unsigned long long)26

--- a/tests/integration/data/regression_output/linux/threads | filter obj.comm == "java" | stack
+++ b/tests/integration/data/regression_output/linux/threads | filter obj.comm == "java" | stack
@@ -1,0 +1,79 @@
+TASK_STRUCT        STATE             COUNT
+==========================================
+0xffffa08960a38000 INTERRUPTIBLE        57
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  futex_wait_queue_me+0xc4
+                  futex_wait+0x10a
+                  do_futex+0x364
+                  __x64_sys_futex+0x13f
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa08960a24500 INTERRUPTIBLE        12
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_hrtimeout_range_clock+0xb9
+                  schedule_hrtimeout_range+0x13
+                  ep_poll+0x258
+                  do_epoll_wait+0xb0
+                  __x64_sys_epoll_wait+0x1e
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa088f740dc00 INTERRUPTIBLE         6
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  pipe_wait+0x70
+                  pipe_read+0x21f
+                  new_sync_read+0x109
+                  __vfs_read+0x29
+                  vfs_read+0x8e
+                  ksys_read+0x5c
+                  __x64_sys_read+0x1a
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa088f740ae00 INTERRUPTIBLE         3
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  do_wait+0x1cb
+                  kernel_wait4+0x89
+                  __do_sys_wait4+0x95
+                  __x64_sys_wait4+0x1e
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa088ef2d1700 INTERRUPTIBLE         2
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_timeout+0x1db
+                  inet_csk_accept+0x246
+                  inet_accept+0x45
+                  __sys_accept4+0x104
+                  __x64_sys_accept+0x1c
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa0889cd4dc00 INTERRUPTIBLE         2
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_hrtimeout_range_clock+0x181
+                  schedule_hrtimeout_range+0x13
+                  ep_poll+0x258
+                  do_epoll_wait+0xb0
+                  __x64_sys_epoll_wait+0x1e
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa088f0979700 INTERRUPTIBLE         1
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_hrtimeout_range_clock+0x181
+                  schedule_hrtimeout_range+0x13
+                  poll_schedule_timeout.constprop.11+0x46
+                  do_sys_poll+0x3d6
+                  __x64_sys_poll+0x3b
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+

--- a/tests/integration/test_linux_generic.py
+++ b/tests/integration/test_linux_generic.py
@@ -82,6 +82,10 @@ POS_CMDS = [
     "stacks -m zfs",
     "stacks -c spa_sync",
     "stacks -m zfs -c spa_sync",
+    "stacks -m zfs -c zthr_procedure",
+    'threads | filter obj.comm == "java" | stack',
+    "stacks -m zfs | count",
+    "echo 0xffffa089669edc00 | stack",
 
     # threads
     "threads",
@@ -139,6 +143,7 @@ NEG_CMDS = [
     "stacks -m bogus",
     "stacks -c bogus",
     "stacks -t bogus",
+    "stacks -m bogus | count",
 ]
 
 CMD_TABLE = POS_CMDS + STRIPPED_POS_CMDS + NEG_CMDS


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build was run locally and any changes were pushed
- [X] Lint has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

resolves https://github.com/delphix/sdb/issues/154

## Decription
Currently, `stacks` is a stand-alone command that prints information about all the stacks of threads on the system. As per https://github.com/delphix/sdb/issues/154, we wanted a way to be able to display the stack for a specific thread (`task_struct`), so it makes sense to have `stacks` be a `PrettyPrinter`. Now we can do something like this:

```
sdb> echo 0xffff9dad75fadb00 | stack
TASK_STRUCT        STATE             COUNT
==========================================
0xffff9dad75fadb00 INTERRUPTIBLE         1
                  __schedule+0x24e
                  schedule+0x2c
                  oom_reaper+0x152
                  kthread+0x121
                  ret_from_fork+0x1f
```
However, we also want to maintain the original "print all the stacks" behavior, which indicates that `stacks` should be a `Locator` as well. I refactored the code so that the filter arguments (by state, function, and module) also apply to the `Locator` behavior, which means we can now do something like this:

```
sdb> stacks | wc
(unsigned long long)459
sdb> stacks -m zfs | wc
(unsigned long long)19
```
In many ways, `stacks` is a more specialized version of `threads`, so I think the most useful thing is to just have it pass along `task_stuct` objects as it's output value. 

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Testing
This re-factor does not change the initial behavior of the `stacks` command (I was able to verify this by seeing that the previous tests still pass)