### PR TITLE
Locators should only use no_input functionality when they are first in a pipeline

### DIFF
--- a/sdb/command.py
+++ b/sdb/command.py
@@ -217,6 +217,7 @@ class Command:
 
     def __init__(self, args: str = "", name: str = "_") -> None:
         self.name = name
+        self.isfirst = False
         self.islast = False
 
         self.parser = type(self)._init_parser(name)
@@ -681,9 +682,12 @@ class Locator(Command):
             baked[type_canonicalize_name(
                 method.input_typename_handled)] = method
 
-        has_input = False
+        if self.isfirst:
+            assert not objs
+            yield from self.no_input()
+            return
+
         for i in objs:
-            has_input = True
             obj_type_name = type_canonical_name(i.type_)
 
             # try subclass-specified input types first, so that they can
@@ -711,8 +715,6 @@ class Locator(Command):
             # error
             raise CommandError(
                 self.name, 'no handler for input of type {}'.format(i.type_))
-        if not has_input:
-            yield from self.no_input()
 
     def _call(self,
               objs: Iterable[drgn.Object]) -> Optional[Iterable[drgn.Object]]:

--- a/sdb/pipeline.py
+++ b/sdb/pipeline.py
@@ -143,6 +143,7 @@ def invoke(myprog: drgn.Program, first_input: Iterable[drgn.Object],
             # a CommandArgumentsError.
             raise CommandArgumentsError(name)
 
+    pipeline[0].isfirst = True
     pipeline[-1].islast = True
 
     # If we have a !, redirect stdout to a shell process. This avoids

--- a/tests/integration/data/regression_output/core/thread | filter obj.comm == "bogus" | thread
+++ b/tests/integration/data/regression_output/core/thread | filter obj.comm == "bogus" | thread
@@ -1,0 +1,2 @@
+task state pid prio comm
+---- ----- --- ---- ----

--- a/tests/integration/test_core_generic.py
+++ b/tests/integration/test_core_generic.py
@@ -70,6 +70,8 @@ POS_CMDS = [
     "spa rpool | filter obj.spa_syncing_txg <= 1624 | member spa_name",
     "spa rpool | filter obj.spa_syncing_txg < 1624 | member spa_name",
     "spa rpool | filter obj.spa_syncing_txg > 1624 | member spa_name",
+    # locator that receives no input from a filter
+    'thread | filter obj.comm == \"bogus\" | thread',
 
     # member - generic
     "member no_object",


### PR DESCRIPTION

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build was run locally and any changes were pushed
- [X] Lint has passed locally and any fixes were made for failures


## Pull request type
resolves #151 
<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->
`Locators` invoke their `no_input` functionality when the command receives no input. This can lead to some unexpected behavior where empty filters appear to match all objects:
 
```
sdb> slabs | filter obj.name == "bogus" | slabs | count
(unsigned long long)131
```
## What is the new behavior?
Now `Locators` will not produce new input mid-pipeline when they are pre-fixed by a filter with no output. 
```
sdb> slabs | filter obj.name == "bogus" | slabs | count
(unsigned long long)0
```

## Does this introduce a breaking change?

I couldn't find any documented use cases or tests that relied on the previous nehavior

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
