### PR TITLE
Use shfmt for shell scripts in .github/scripts (#118)

### DIFF
--- a/.github/scripts/download-dump-from-s3.sh
+++ b/.github/scripts/download-dump-from-s3.sh
@@ -25,16 +25,16 @@ fi
 
 echo "initiating download of $1 from S3 ..."
 /usr/local/bin/aws s3 cp --no-sign-request s3://sdb-regression-dumps/$1 .
-[ $? -eq 0 ]  || exit 1
+[ $? -eq 0 ] || exit 1
 
 echo "decompressing dump ..."
 tar -x --lzma -f $1
 
 echo "moving contents to tests/integration/data ..."
 mv dump-data/* $DATA_DIR
-[ $? -eq 0 ]  || exit 1
+[ $? -eq 0 ] || exit 1
 
 rmdir dump-data
-[ $? -eq 0 ]  || exit 1
+[ $? -eq 0 ] || exit 1
 
 echo "Done"

--- a/.github/scripts/install-shfmt.sh
+++ b/.github/scripts/install-shfmt.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -eux
+
+if [[ ! -f /usr/local/bin/shfmt ]]; then
+	sudo wget -nv -O /usr/local/bin/shfmt \
+		https://github.com/mvdan/sh/releases/download/v3.0.2/shfmt_v3.0.2_linux_amd64
+	sudo chmod +x /usr/local/bin/shfmt
+fi
+echo "shfmt version $(/usr/local/bin/shfmt -version) is installed."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,3 +101,12 @@ jobs:
       - run: python3 -m pip install mypy==0.730
       - run: python3 -m mypy --strict --allow-untyped-calls --show-error-codes -p sdb
       - run: python3 -m mypy --strict --ignore-missing-imports --show-error-codes -p tests
+  #
+  # Verify that "shfmt" ran successfully against our shell scripts.
+  #
+  shfmt:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - run: ./.github/scripts/install-shfmt.sh
+      - run: /usr/local/bin/shfmt -d .github/scripts/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,4 +109,4 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: ./.github/scripts/install-shfmt.sh
-      - run: /usr/local/bin/shfmt -d .github/scripts/
+      - run: /usr/local/bin/shfmt -d .


### PR DESCRIPTION
Commit 1: Introduce the check (Should fail testing because there are formatting errors)

Testing Failure Output:
```
--- .github/scripts/download-dump-from-s3.sh.orig
+++ .github/scripts/download-dump-from-s3.sh
@@ -1,41 +1,41 @@
 #!/bin/bash -eu
 
 #
 # Assumptions for this to work:
 # [1] This script is executed from the root of the SDB repo
 # [2] The archive downloaded from S3 is lzma-compressed
 # [3] The archive's contents have the following hierarchy:
 #           dump-data
 #           ├── dump.201912060006
 #           ├── mods
 #           │   ├── avl
 #           │   │   └── zavl.ko
 #           .....
 #           │   └── zfs
 #           │       └── zfs.ko
 #           └── vmlinux-5.0.0-36-generic
 #
 
 DATA_DIR="tests/integration/data"
...

echo "initiating download of $1 from S3 ..."
 /usr/local/bin/aws s3 cp --no-sign-request s3://sdb-regression-dumps/$1 .
-[ $? -eq 0 ]  || exit 1
+[ $? -eq 0 ] || exit 1
 
 echo "decompressing dump ..."
 tar -x --lzma -f $1
 
 echo "moving contents to tests/integration/data ..."
 mv dump-data/* $DATA_DIR
-[ $? -eq 0 ]  || exit 1
+[ $? -eq 0 ] || exit 1
 
 rmdir dump-data
-[ $? -eq 0 ]  || exit 1
+[ $? -eq 0 ] || exit 1
 
 echo "Done"
 
##[error]Process completed with exit code 1.
```

Commit 2: Fixes the above formatting errors so testing can pass