### PR TITLE
Improve history file and dump file error handling on the CLI

### DIFF
--- a/sdb/internal/cli.py
+++ b/sdb/internal/cli.py
@@ -154,7 +154,11 @@ def setup_target(args: argparse.Namespace) -> drgn.Program:
     """
     prog = drgn.Program()
     if args.core:
-        prog.set_core_dump(args.core)
+        try:
+            prog.set_core_dump(args.core)
+        except FileNotFoundError:
+            print(f"sdb: no such file: '{args.core}'")
+            sys.exit(2)
 
         #
         # This is currently a short-coming of drgn. Whenever we

--- a/sdb/internal/cli.py
+++ b/sdb/internal/cli.py
@@ -212,7 +212,7 @@ def main() -> None:
         return
 
     repl = REPL(prog, list(sdb.get_registered_commands().keys()))
-    repl.enable_history()
+    repl.enable_history(os.getenv('SDB_HISTORY_FILE', '~/.sdb_history'))
     if args.eval:
         exit_code = repl.eval_cmd(args.eval)
         sys.exit(exit_code)

--- a/sdb/internal/repl.py
+++ b/sdb/internal/repl.py
@@ -72,14 +72,23 @@ class REPL:
         self.target = target
         self.histfile = ""
         readline.set_completer(REPL.__make_completer(vocabulary))
+        readline.parse_and_bind("tab: complete")
 
-    def enable_history(self, history_file: str = '~/.sdb_history') -> None:
+    def enable_history(self, history_file: str) -> None:
         self.histfile = os.path.expanduser(history_file)
         try:
             readline.read_history_file(self.histfile)
         except FileNotFoundError:
             pass
-        readline.parse_and_bind("tab: complete")
+        except PermissionError:
+            self.histfile = ""
+            print(
+                f"Warning: You don't have permissions to read {history_file} and\n"
+                "         the command history of this session won't be saved.\n"
+                "         Either change this file's permissions, recreate it,\n"
+                "         or use an alternate path with the SDB_HISTORY_FILE\n"
+                "         environment variable.")
+            return
         readline.set_history_length(1000)
         atexit.register(readline.write_history_file, self.histfile)
 


### PR DESCRIPTION
# Commit A
fix: sdb requires sudo just for history file (#56)
feature: allow alternate paths for history file

= Issue

Having a history file created using sudo first then trying to use SDB
on a crash dump without sudo:
```
$ sdb vmlinux-5.0.0-36-generic dump.201912060006 -s mods
Traceback (most recent call last):
  File "/usr/bin/sdb", line 11, in <module>
    load_entry_point('sdb==0.1.0', 'console_scripts', 'sdb')()
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/cli.py", line 215, in main
    repl.enable_history(os.getenv('SDB_HISTORY_FILE', '~/.sdb_history'))
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/repl.py", line 79, in enable_history
    readline.read_history_file(self.histfile)
PermissionError: [Errno 13] Permission denied
...(sdb exits)...
```

= Testing

With this patch we print a warning and drive on:
```
$ sdb vmlinux-5.0.0-36-generic dump.201912060006 -s mods
Warning: You don't have permissions to read ~/.sdb_history and
         the command history of this session won't be saved.
         Either change this file's permissions, recreate it,
         or use an alternate path with the SDB_HISTORY_FILE
         environment variable.
sdb> addr spa_namespace_avl
(avl_tree_t *)spa_namespace_avl+0x0 = 0xffffffffc07d0fe0
```

Again with this patch in the same situation, we can provide an
alternative path:
```
$ SDB_HISTORY_FILE=./test-history sdb vmlinux-5.0.0-36-generic dump.201912060006 -s mods
sdb> addr init_task
(struct task_struct *)init_task+0x0 = 0xffffffff8c817740
sdb> spa
ADDR               NAME
------------------------------------------------------------
0xffffa0894e720000 data
0xffffa089413b8000 meta-domain
0xffffa08955c44000 rpool
sdb>
(^D)

$ cat test-history
addr init_task
spa

$ # running sdb with the same history file we ensure that it works
$ SDB_HISTORY_FILE=./test-history sdb vmlinux-5.0.0-36-generic dump.201912060006 -s mods
sdb> spa
ADDR               NAME
------------------------------------------------------------
0xffffa0894e720000 data
0xffffa089413b8000 meta-domain
0xffffa08955c44000 rpool
```

= Other Notes

This patch also helps with situations where SDB gets stuck because the
filesystem backing its history file has crashed and it cannot append
anything to it. For cases like these with the above patch we should
be able to get unstuck by specifying SDB_HISTORY_FILE=/dev/null, like
this:

```
$ SDB_HISTORY_FILE=/dev/null sdb vmlinux-5.0.0-36-generic dump.201912060006 -s mods
sdb> addr spa_namespace_avl
(avl_tree_t *)spa_namespace_avl+0x0 = 0xffffffffc07d0fe0
```

# Commit B
fix: ugly error handling when dump file doesn't exist

= Issue

Specifying a wrong argument for a crash dump shows the following error:
```
$ sdb vmlinux-5.0.0-36-generic bogus.dump -s mods
Traceback (most recent call last):
  File "/usr/bin/sdb", line 11, in <module>
    load_entry_point('sdb==0.1.0', 'console_scripts', 'sdb')()
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/cli.py", line 209, in main
    prog = setup_target(args)
  File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/cli.py", line 157, in setup_target
    prog.set_core_dump(args.core)
FileNotFoundError: [Errno 2] No such file or directory: 'bogus.dump'
```

= Patch

With this patch:
```
$ sdb vmlinux-5.0.0-36-generic bogus.dump -s mods
sdb: no such file: 'bogus.dump'
```