### PR TITLE
Fix nightly yapf warnings + minor refactoring

### DIFF
--- a/sdb/commands/internal/table.py
+++ b/sdb/commands/internal/table.py
@@ -35,11 +35,11 @@ class Table:
     #
     # pylint: disable=bad-continuation
     def __init__(
-        self,
-        fields: List[str],
-        rjustfields: Optional[Set[str]] = None,
-        formatters: Optional[Dict[str, Callable[[Any], str]]] = None
-    ) -> None:
+            self,
+            fields: List[str],
+            rjustfields: Optional[Set[str]] = None,
+            formatters: Optional[Dict[str, Callable[[Any],
+                                                    str]]] = None) -> None:
         self.fields = fields
 
         if rjustfields is None:
@@ -93,13 +93,11 @@ class Table:
                 continue
 
             line_fields = []
-            for fid in range(len(self.fields)):
-                if self.fields[fid] in self.rjustfields:
+            for fid, field in enumerate(self.fields):
+                if field in self.rjustfields:
                     line_fields.append(
-                        f"{row_values[fid]:>{self.maxfieldlen[self.fields[fid]]}}"
-                    )
+                        f"{row_values[fid]:>{self.maxfieldlen[field]}}")
                 else:
                     line_fields.append(
-                        f"{row_values[fid]:<{self.maxfieldlen[self.fields[fid]]}}"
-                    )
+                        f"{row_values[fid]:<{self.maxfieldlen[field]}}")
             print(delimeter.join(line_fields))

--- a/sdb/commands/linux/per_cpu.py
+++ b/sdb/commands/linux/per_cpu.py
@@ -96,6 +96,6 @@ class LxPerCpuCounterSum(sdb.SingleInputCommand):
     def _call_one(self, obj: drgn.Object) -> Iterable[drgn.Object]:
         try:
             sum_ = drgn_percpu.percpu_counter_sum(obj)
-        except AttributeError as err:
+        except AttributeError:
             raise sdb.CommandError(self.name, "input is not a percpu_counter")
         yield drgn.Object(sdb.get_prog(), type="s64", value=sum_)

--- a/sdb/commands/linux/slabs.py
+++ b/sdb/commands/linux/slabs.py
@@ -110,8 +110,8 @@ class Slabs(sdb.Locator, sdb.PrettyPrinter):
             yield from sorted(
                 self.__no_input_iterator(),
                 key=Slabs.FIELDS[self.args.s],
-                reverse=(
-                    self.args.s not in Slabs.DEFAULT_INCREASING_ORDER_FIELDS))
+                reverse=(self.args.s
+                         not in Slabs.DEFAULT_INCREASING_ORDER_FIELDS))
         else:
             yield from self.__no_input_iterator()
 

--- a/sdb/commands/spl/spl_kmem_caches.py
+++ b/sdb/commands/spl/spl_kmem_caches.py
@@ -100,8 +100,8 @@ class SplKmemCaches(sdb.Locator, sdb.PrettyPrinter):
             yield from sorted(
                 kmem.for_each_spl_kmem_cache(),
                 key=SplKmemCaches.FIELDS[self.args.s],
-                reverse=(self.args.s not in
-                         SplKmemCaches.DEFAULT_INCREASING_ORDER_FIELDS))
+                reverse=(self.args.s
+                         not in SplKmemCaches.DEFAULT_INCREASING_ORDER_FIELDS))
         else:
             yield from kmem.for_each_spl_kmem_cache()
 

--- a/sdb/commands/zfs/internal/__init__.py
+++ b/sdb/commands/zfs/internal/__init__.py
@@ -17,7 +17,6 @@
 # pylint: disable=missing-docstring
 
 import os
-from typing import List
 
 import drgn
 import sdb

--- a/sdb/commands/zfs/metaslab.py
+++ b/sdb/commands/zfs/metaslab.py
@@ -192,6 +192,6 @@ class Metaslab(sdb.Locator, sdb.PrettyPrinter):
                             i, int(vdev.vdev_ms_count), int(vdev.vdev_id)))
                 yield vdev.vdev_ms[i]
         else:
-            for i in range(0, int(vdev.vdev_ms_count)):
+            for i in range(int(vdev.vdev_ms_count)):
                 msp = vdev.vdev_ms[i]
                 yield msp

--- a/sdb/commands/zfs/vdev.py
+++ b/sdb/commands/zfs/vdev.py
@@ -130,6 +130,6 @@ class Vdev(sdb.Locator, sdb.PrettyPrinter):
                 self.name, "when providing a vdev, "
                 "specific child vdevs can not be requested")
         yield vdev
-        for cid in range(0, int(vdev.vdev_children)):
+        for cid in range(int(vdev.vdev_children)):
             cvd = vdev.vdev_child[cid]
             yield from self.from_vdev(cvd)

--- a/sdb/pipeline.py
+++ b/sdb/pipeline.py
@@ -1,4 +1,4 @@
-#o
+#
 # Copyright 2019 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from setuptools import setup, find_packages
+from setuptools import setup
 
 setup(
     name='sdb',


### PR DESCRIPTION
Today's nightly failed because the new version of yapf changed its formatting for a specific form.
The nightly run: https://github.com/delphix/sdb/runs/613792165?check_suite_focus=true

This commit applies the new `yapf` style.

Some minor refactoring are added as a side-change in this commit:
[1] 1 unused variable (`err` in `per_cpu.py`) is  removed
[2] 2 unused imports are removed (`List` in `zfs/internal/__init__.py` and `find_packages` in `setup.py`
[3] 3 `range()` refactorings (2 `range(0, X)` to `range(X)` and one `range()` -> `enumerate()`)