### PR TITLE
pylint upgrade: fix new warnings

### DIFF
--- a/sdb/command.py
+++ b/sdb/command.py
@@ -145,7 +145,7 @@ class Command:
             # conditional control flow.
             #
             # pylint: disable=unsubscriptable-object
-            it_text = f"This command accepts inputs of type 'void *',"
+            it_text = "This command accepts inputs of type 'void *',"
             if cls.input_type[-1] == '*':
                 it_text += f" and '{cls.input_type[:-1].strip()}',"
             it_text += f" which will be converted to '{cls.input_type}'."

--- a/sdb/commands/zfs/histograms.py
+++ b/sdb/commands/zfs/histograms.py
@@ -143,7 +143,7 @@ class ZFSHistogram(sdb.Command):
 
     def _call(self, objs: Iterable[drgn.Object]) -> None:
         for obj in objs:
-            print(f'seg-size   count')
+            print('seg-size   count')
             print(f'{"-" * 8}   {"-" * 5}')
             ZFSHistogram.print_histogram(obj, self.args.offset)
             ZFSHistogram.print_histogram_median(obj, self.args.offset)


### PR DESCRIPTION
Issues before:
```
$ python3 -m pylint -d duplicate-code -d invalid-name sdb
************* Module sdb.command
sdb/command.py:148:22: W1309: Using an f-string that does not have any interpolated variables (f-string-without-interpolation)
************* Module sdb.commands.zfs.histograms
sdb/commands/zfs/histograms.py:146:18: W1309: Using an f-string that does not have any interpolated variables (f-string-without-interpolation)

-------------------------------------------------------------------
Your code has been rated at 9.99/10 (previous run: 10.00/10, -0.00)
```