### PR TITLE
Fix stacks test

### DIFF
--- a/sdb/commands/internal/__init__.py
+++ b/sdb/commands/internal/__init__.py
@@ -24,7 +24,3 @@ for path in glob.glob("{}/*.py".format(os.path.dirname(__file__))):
     if path != __file__:
         module = os.path.splitext(os.path.basename(path))[0]
         importlib.import_module("sdb.commands.internal.{}".format(module))
-
-for path in glob.glob("{}/*/__init__.py".format(os.path.dirname(__file__))):
-    module = os.path.basename(os.path.dirname(path))
-    importlib.import_module("sdb.commands.internal.{}".format(module))

--- a/sdb/commands/linux/internal/__init__.py
+++ b/sdb/commands/linux/internal/__init__.py
@@ -24,7 +24,3 @@ for path in glob.glob("{}/*.py".format(os.path.dirname(__file__))):
     if path != __file__:
         module = os.path.splitext(os.path.basename(path))[0]
         importlib.import_module("sdb.commands.linux.internal.{}".format(module))
-
-for path in glob.glob("{}/*/__init__.py".format(os.path.dirname(__file__))):
-    module = os.path.basename(os.path.dirname(path))
-    importlib.import_module("sdb.commands.linux.internal.{}".format(module))

--- a/sdb/commands/spl/internal/__init__.py
+++ b/sdb/commands/spl/internal/__init__.py
@@ -24,7 +24,3 @@ for path in glob.glob("{}/*.py".format(os.path.dirname(__file__))):
     if path != __file__:
         module = os.path.splitext(os.path.basename(path))[0]
         importlib.import_module("sdb.commands.spl.internal.{}".format(module))
-
-for path in glob.glob("{}/*/__init__.py".format(os.path.dirname(__file__))):
-    module = os.path.basename(os.path.dirname(path))
-    importlib.import_module("sdb.commands.spl.internal.{}".format(module))

--- a/tests/integration/data/regression_output/linux/stacks
+++ b/tests/integration/data/regression_output/linux/stacks
@@ -241,6 +241,12 @@ TASK_STRUCT        STATE             COUNT
                   ret_from_fork+0x1f
 
 0xffffa08966a01700 RUNNING               1
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_timeout+0x169
+                  rcu_gp_kthread+0x572
+                  kthread+0x121
+                  ret_from_fork+0x1f
 
 0xffffa08966a6dc00 INTERRUPTIBLE         1
                   __schedule+0x2c0

--- a/tests/integration/data/regression_output/linux/stacks -a
+++ b/tests/integration/data/regression_output/linux/stacks -a
@@ -765,6 +765,12 @@ TASK_STRUCT        STATE
                   ret_from_fork+0x1f
 
 0xffffa08966a01700 RUNNING         
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_timeout+0x169
+                  rcu_gp_kthread+0x572
+                  kthread+0x121
+                  ret_from_fork+0x1f
 
 0xffffa08966a6dc00 INTERRUPTIBLE   
                   __schedule+0x2c0


### PR DESCRIPTION
Commit:
```
drgn fixed the bug where runnable threads are distinguished
from running threads and thus it correctly goes to look for
them in memory instead of the PRSTATUS notes.

drgn commit:
github.com/osandov/drgn/commit/eea5422546004d29f85e4d0b94d62fd7564db15a
```

Side Commit:
```
Eliminate some dead code for internal __init__.py files
```