### PR TITLE
Lint Errors and spl_kmem_caches regression

### DIFF
--- a/tests/integration/test_core_generic.py
+++ b/tests/integration/test_core_generic.py
@@ -16,6 +16,7 @@
 
 # pylint: disable=missing-module-docstring
 # pylint: disable=missing-function-docstring
+# pylint: disable=not-callable
 
 from typing import Any
 

--- a/tests/integration/test_linux_generic.py
+++ b/tests/integration/test_linux_generic.py
@@ -17,6 +17,7 @@
 # pylint: disable=missing-module-docstring
 # pylint: disable=missing-function-docstring
 # pylint: disable=line-too-long
+# pylint: disable=not-callable
 
 from typing import Any
 

--- a/tests/integration/test_spl_generic.py
+++ b/tests/integration/test_spl_generic.py
@@ -17,6 +17,7 @@
 # pylint: disable=missing-module-docstring
 # pylint: disable=missing-function-docstring
 # pylint: disable=line-too-long
+# pylint: disable=not-callable
 
 from typing import Any
 

--- a/tests/integration/test_zfs_generic.py
+++ b/tests/integration/test_zfs_generic.py
@@ -17,6 +17,7 @@
 # pylint: disable=missing-module-docstring
 # pylint: disable=missing-function-docstring
 # pylint: disable=line-too-long
+# pylint: disable=not-callable
 
 from typing import Any
 

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -15,6 +15,7 @@
 #
 
 # pylint: disable=missing-docstring
+# pylint: disable=not-callable
 
 from typing import List, Tuple
 


### PR DESCRIPTION
### First Commit: Disable pylint false-positives for pytest

Context:
Issue: pytest-dev/pytest#7473
PR that was just merged: pytest-dev/pytest#7476

Opened issue to get rid of this once `pytest` is updated:
#235

### Second Commit: Update spl_kmem_caches command to be aware of new percpu counter

The following commit from ZoL introduced this new counter to be used instead of what sdb was looking at before
openzfs/zfs@ec1fea4

Note that since our test crash dump was generated with old bits, we'd need a new crash dump to test that new condition. Until that happens I decided that the following manual testing should suffice.

= Manual testing

Before:
```
sdb> spl_kmem_caches | filter 'obj.skc_linux_cache != 0x0' | spl_kmem_caches
name                     entry_size active_objs active_memory                         source total_memory util
------------------------ ---------- ----------- ------------- ------------------------------ ------------ ----
zio_link_cache                   48           0          0.0B           zio_link_cache[SLUB]       59.8KB    0
zio_data_buf_8192              8192           0          0.0B        zio_data_buf_8192[SLUB]      320.0KB    0
zio_data_buf_7168              8192           0          0.0B        zio_data_buf_7168[SLUB]      288.0KB    0
zio_data_buf_6144              8192           0          0.0B        zio_data_buf_6144[SLUB]      288.0KB    0
zio_data_buf_5120              8192           0          0.0B        zio_data_buf_5120[SLUB]      352.0KB    0
zio_data_buf_512                512           0          0.0B         zio_data_buf_512[SLUB]        1.3MB    0
zio_data_buf_4096              4096           0          0.0B        zio_data_buf_4096[SLUB]      192.0KB    0
zio_data_buf_3584              3584           0          0.0B        zio_data_buf_3584[SLUB]      220.5KB    0
...<cropped>...
```

After:
```
sdb> spl_kmem_caches | filter 'obj.skc_linux_cache != 0x0' | spl_kmem_caches
name                     entry_size active_objs active_memory                         source total_memory util
------------------------ ---------- ----------- ------------- ------------------------------ ------------ ----
dnode_t                        1240       17220        20.4MB                  dnode_t[SLUB]       20.5MB   99
zio_buf_16384                 16384        1263        19.7MB            zio_buf_16384[SLUB]       20.0MB   98
zfs_znode_cache                1096       15927        16.6MB          zfs_znode_cache[SLUB]       16.8MB   99
arc_buf_hdr_t_full              456       32307        14.0MB       arc_buf_hdr_t_full[SLUB]       14.1MB   99
dmu_buf_impl_t                  512       18062         8.8MB           dmu_buf_impl_t[SLUB]        9.1MB   97
abd_t                           248       32308         7.6MB                    abd_t[SLUB]        7.7MB   98
sa_cache                        256       15919         3.9MB                 sa_cache[SLUB]        3.9MB   99
zio_buf_512                     512        2654         1.3MB              zio_buf_512[SLUB]        1.3MB   98
zio_data_buf_1024              1024        1051         1.0MB        zio_data_buf_1024[SLUB]        1.0MB   98
zio_data_buf_512                512        1604       802.0KB         zio_data_buf_512[SLUB]        1.4MB   57
zfs_btree_leaf_cache           4096          66       264.0KB     zfs_btree_leaf_cache[SLUB]      512.0KB   51
zio_data_buf_5120              8192          31       248.0KB        zio_data_buf_5120[SLUB]      352.0KB   70
zio_data_buf_12288            12288          19       228.0KB       zio_data_buf_12288[SLUB]      336.0KB   67
...<cropped>...
```

Prakash pointed out a bug that was missed by my manual testing above where SPL-based caches would use the percpu counter. This was missed because I was only looking at SLUB-based caches in the above out. After re-iterating now both work as before.

```
sdb> spl_kmem_caches
name                     entry_size active_objs active_memory                         source total_memory util
------------------------ ---------- ----------- ------------- ------------------------------ ------------ ----
dnode_t                        1240       18266        21.6MB                  dnode_t[SLUB]       21.8MB   99
zio_buf_16384                 16384        1311        20.5MB            zio_buf_16384[SLUB]       20.8MB   98
zfs_znode_cache                1096       16888        17.7MB          zfs_znode_cache[SLUB]       17.8MB   99
arc_buf_hdr_t_full              456       33713        14.7MB       arc_buf_hdr_t_full[SLUB]       14.7MB   99
zio_buf_131072               135680          88        11.4MB           zio_buf_131072[SPL ]       18.6MB   61
dmu_buf_impl_t                  512       19150         9.4MB           dmu_buf_impl_t[SLUB]        9.5MB   98
abd_t                           248       33714         8.0MB                    abd_t[SLUB]        8.1MB   98
zio_data_buf_131072          135680          40         5.2MB      zio_data_buf_131072[SPL ]       10.4MB   50
zio_data_buf_114688          119296          40         4.6MB      zio_data_buf_114688[SPL ]        5.5MB   83
sa_cache                        256       16880         4.1MB                 sa_cache[SLUB]        4.1MB   99
zio_data_buf_98304           102912          40         3.9MB       zio_data_buf_98304[SPL ]        4.7MB   83
zio_data_buf_57344            61952          64         3.8MB       zio_data_buf_57344[SPL ]        4.3MB   88
zio_data_buf_65536            70144          56         3.7MB       zio_data_buf_65536[SPL ]        4.3MB   87
zio_data_buf_49152            53760          72         3.7MB       zio_data_buf_49152[SPL ]        4.1MB   90
...<cropped>...
```