### PR TITLE
Fix Regression Failures; Type Error Handling Improvements; Strict Type Checking Updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,10 +94,7 @@ jobs:
   #     comes with Ubuntu is 0.75 which has a couple of bugs triggered
   #     by our codebase (they've been resolved on trunk though so we
   #     may want to change this soon).
-  # [2] We supply --allow-untyped-calls because even though drgn has
-  #     stubs on typeshed now, there are still some untyped functions
-  #     (mainly in the helper API).
-  # [3] We supply --ignore-missing-imports to the tests package because
+  # [2] We supply --ignore-missing-imports to the tests package because
   #     pytest doesn't provide stubs on typeshed.
   #
   mypy:
@@ -109,7 +106,7 @@ jobs:
           python-version: '3.6'
       - run: ./.github/scripts/install-drgn.sh
       - run: python3 -m pip install mypy==0.730
-      - run: python3 -m mypy --strict --allow-untyped-calls --show-error-codes -p sdb
+      - run: python3 -m mypy --strict --show-error-codes -p sdb
       - run: python3 -m mypy --strict --ignore-missing-imports --show-error-codes -p tests
   #
   # Verify that "shfmt" ran successfully against our shell scripts.

--- a/sdb/command.py
+++ b/sdb/command.py
@@ -643,13 +643,13 @@ class Walker(Command):
         the types as we go.
         """
         assert self.input_type is not None
-        type_ = target.get_type(self.input_type)
+        expected_type = type_canonicalize_name(self.input_type)
         for obj in objs:
-            if obj.type_ != type_:
+            if type_canonical_name(obj.type_) != expected_type:
                 raise CommandError(
                     self.name,
                     'expected input of type {}, but received {}'.format(
-                        type_, obj.type_))
+                        expected_type, type_canonical_name(obj.type_)))
 
             yield from self.walk(obj)
 

--- a/sdb/commands/ptype.py
+++ b/sdb/commands/ptype.py
@@ -50,16 +50,15 @@ class PType(sdb.Command):
 
         Print enums and unions:
 
-            sdb> ptype zfs_case v_t thread_union
+            sdb> ptype zfs_case 'struct v' thread_union
             enum zfs_case {
                     ZFS_CASE_SENSITIVE = 0,
                     ZFS_CASE_INSENSITIVE = 1,
                     ZFS_CASE_MIXED = 2,
             }
-            typedef union {
-                    iv_t e;
-                    uint8_t b[8];
-            } v_t
+            struct v {
+                    uint8_t b[16];
+            }
             union thread_union {
                     struct task_struct task;
                     unsigned long stack[2048];

--- a/tests/integration/data/regression_output/core/ptype $abc
+++ b/tests/integration/data/regression_output/core/ptype $abc
@@ -1,0 +1,1 @@
+sdb: ptype: input '$abc' is not a valid type name

--- a/tests/integration/data/regression_output/core/ptype 'a b c'
+++ b/tests/integration/data/regression_output/core/ptype 'a b c'
@@ -1,0 +1,1 @@
+sdb: ptype: input 'a b c' is not a valid type name

--- a/tests/integration/data/regression_output/core/ptype 'bogus union'
+++ b/tests/integration/data/regression_output/core/ptype 'bogus union'
@@ -1,0 +1,1 @@
+sdb: ptype: input 'bogus union' is not a valid type name

--- a/tests/integration/data/regression_output/core/ptype 'struct bogus'
+++ b/tests/integration/data/regression_output/core/ptype 'struct bogus'
@@ -1,0 +1,1 @@
+sdb: ptype: couldn't find type 'struct bogus'

--- a/tests/integration/data/regression_output/core/ptype 'struct union'
+++ b/tests/integration/data/regression_output/core/ptype 'struct union'
@@ -1,0 +1,1 @@
+sdb: ptype: input 'struct union' is not a valid type name

--- a/tests/integration/data/regression_output/core/ptype 'struct'
+++ b/tests/integration/data/regression_output/core/ptype 'struct'
@@ -1,0 +1,1 @@
+sdb: ptype: skip keyword 'struct' or quote your type "struct <typename>"

--- a/tests/integration/data/regression_output/core/ptype 'union struct struct'
+++ b/tests/integration/data/regression_output/core/ptype 'union struct struct'
@@ -1,0 +1,1 @@
+sdb: ptype: input 'union struct struct' is not a valid type name

--- a/tests/integration/data/regression_output/core/ptype 2abc
+++ b/tests/integration/data/regression_output/core/ptype 2abc
@@ -1,0 +1,1 @@
+sdb: ptype: input '2abc' is not a valid type name

--- a/tests/integration/data/regression_output/core/ptype @
+++ b/tests/integration/data/regression_output/core/ptype @
@@ -1,0 +1,1 @@
+sdb: ptype: input '@' is not a valid type name

--- a/tests/integration/data/regression_output/core/ptype zfs_case 'struct v' thread_union
+++ b/tests/integration/data/regression_output/core/ptype zfs_case 'struct v' thread_union
@@ -3,10 +3,9 @@ enum zfs_case {
 	ZFS_CASE_INSENSITIVE = 1,
 	ZFS_CASE_MIXED = 2,
 }
-typedef union {
-	iv_t e;
-	uint8_t b[8];
-} v_t
+struct v {
+	uint8_t b[16];
+}
 union thread_union {
 	struct task_struct task;
 	unsigned long stack[2048];

--- a/tests/integration/data/regression_output/linux/echo 0x0 | cpu_counter_sum
+++ b/tests/integration/data/regression_output/linux/echo 0x0 | cpu_counter_sum
@@ -1,1 +1,1 @@
-sdb: cpu_counter_sum: invalid memory access: could not read memory from kdump: Cannot get page I/O address: PDPT table not present: pgd[0] = 0x0: 0x8
+sdb: cpu_counter_sum: invalid memory access: could not read memory from kdump: Cannot get page I/O address: PDPT table not present: p4d[0] = 0x0: 0x8

--- a/tests/integration/test_core_generic.py
+++ b/tests/integration/test_core_generic.py
@@ -119,7 +119,7 @@ POS_CMDS = [
     # ptype
     "ptype spa_t",
     "ptype spa vdev",
-    "ptype zfs_case v_t thread_union",
+    "ptype zfs_case 'struct v' thread_union",
     "ptype 'struct spa'",
 
     # sizeof
@@ -181,8 +181,18 @@ NEG_CMDS = [
 
     # ptype - bogus type
     "ptype bogus_t",
+    "ptype 'struct bogus'",
+    "ptype 'a b c'",
     # ptype - freestanding C keyword
     "ptype struct spa",
+    "ptype 'struct'",
+    "ptype 'struct union'",
+    "ptype 'bogus union'",
+    "ptype 'union struct struct'",
+    # ptype - invalid characters
+    "ptype @",
+    "ptype 2abc",
+    "ptype $abc",
 
     # pretty printer passed incorrect type
     "spa | range_tree",


### PR DESCRIPTION
## Commit 1

*mypy: disallow untyped calls for the sdb directory*

There was recent work in drgn where all the helpers were annotated
with types. With that work in place we no longer need to allow
untyped calls.

## Commit 2 (Fixes Regression - original PR from Matt here: https://github.com/delphix/sdb/pull/210)

*Walker should check for canonicalized type names*

As we know, drgn type equality does not work right, so we need to
compare canonicalized type names. When combined with openzfs/zfs#10236,
`zfs_dbgmsg` now works on ztest core dumps.

Serapheim Note:
With drgn changing its type rules once again this commit is now needed
for existing tests to not fail.

## Commit 3 (Fixes Regression)

*update regression output*

drgn recently updated its error messages when it comes to page
table lookups to match the latest terminology used by the kernel.

## Commit 4 (Fixes Regression; Error-handling improvements with new tests)

*ptype: remove anonymous union test and improve error handling*

In the past we used to assume lazy type rules from drgn and printing
an anonymous union or struct from its typedef just worked.
Unfortunately, with the latest updates for types in drgn, this no
longer works so part of this commit removes the expectation of
this functionality from our tests. We may want to introduce this
functionality again in the future implemented in a different way.
Fortunately, these kind of types are rare.

The second part of this commit improves the error handling of
looking up types.