### PR TITLE
Show cache devices in spa -v output

### DIFF
--- a/tests/integration/data/regression_output/zfs/spa -mH
+++ b/tests/integration/data/regression_output/zfs/spa -mH
@@ -413,6 +413,7 @@ ADDR               NAME
                Approx. Median: 192.0MB
       0xffffa08948af8000 HEALTHY NONE      /dev/sdb1
       0xffffa08949ff8000 HEALTHY NONE      /dev/sdc1
+      -                  -       -     logs
       0xffffa08949e58000 HEALTHY NONE    /dev/sdd1
           ** No histogram data available **
            ADDR                 ID           OFFSET     FREE  FRAG     UCMU
@@ -582,6 +583,8 @@ ADDR               NAME
       0xffffa08953aac000 HEALTHY NONE      /tmp/dks0
       0xffffa08953ab0000 HEALTHY NONE      /tmp/dks1
       0xffffa08953ab4000 HEALTHY NONE      /tmp/dks2
+      -                  -       -     cache
+      0xffffa088ce7d0000 HEALTHY NONE    /tmp/dks3
 0xffffa08955c44000 rpool
      ** No histogram data available **
       ADDR               STATE   AUX  DESCRIPTION

--- a/tests/integration/data/regression_output/zfs/spa -v
+++ b/tests/integration/data/regression_output/zfs/spa -v
@@ -7,6 +7,7 @@ ADDR               NAME
       0xffffa08949ff4000 HEALTHY NONE    mirror
       0xffffa08948af8000 HEALTHY NONE      /dev/sdb1
       0xffffa08949ff8000 HEALTHY NONE      /dev/sdc1
+      -                  -       -     logs
       0xffffa08949e58000 HEALTHY NONE    /dev/sdd1
 0xffffa089413b8000 meta-domain
       ADDR               STATE   AUX  DESCRIPTION
@@ -16,6 +17,8 @@ ADDR               NAME
       0xffffa08953aac000 HEALTHY NONE      /tmp/dks0
       0xffffa08953ab0000 HEALTHY NONE      /tmp/dks1
       0xffffa08953ab4000 HEALTHY NONE      /tmp/dks2
+      -                  -       -     cache
+      0xffffa088ce7d0000 HEALTHY NONE    /tmp/dks3
 0xffffa08955c44000 rpool
       ADDR               STATE   AUX  DESCRIPTION
       ------------------------------------------------------------

--- a/tests/integration/data/regression_output/zfs/spa -vH
+++ b/tests/integration/data/regression_output/zfs/spa -vH
@@ -53,6 +53,7 @@ ADDR               NAME
           Approx. Median: 192.0MB
       0xffffa08948af8000 HEALTHY NONE      /dev/sdb1
       0xffffa08949ff8000 HEALTHY NONE      /dev/sdc1
+      -                  -       -     logs
       0xffffa08949e58000 HEALTHY NONE    /dev/sdd1
           ** No histogram data available **
 0xffffa089413b8000 meta-domain
@@ -105,6 +106,8 @@ ADDR               NAME
       0xffffa08953aac000 HEALTHY NONE      /tmp/dks0
       0xffffa08953ab0000 HEALTHY NONE      /tmp/dks1
       0xffffa08953ab4000 HEALTHY NONE      /tmp/dks2
+      -                  -       -     cache
+      0xffffa088ce7d0000 HEALTHY NONE    /tmp/dks3
 0xffffa08955c44000 rpool
      ** No histogram data available **
       ADDR               STATE   AUX  DESCRIPTION

--- a/tests/integration/data/regression_output/zfs/spa -vm
+++ b/tests/integration/data/regression_output/zfs/spa -vm
@@ -24,6 +24,7 @@ ADDR               NAME
            0xffffa0894e631000   14      0x1c0000000    511MB    0%      4KB
       0xffffa08948af8000 HEALTHY NONE      /dev/sdb1
       0xffffa08949ff8000 HEALTHY NONE      /dev/sdc1
+      -                  -       -     logs
       0xffffa08949e58000 HEALTHY NONE    /dev/sdd1
            ADDR                 ID           OFFSET     FREE  FRAG     UCMU
            -----------------------------------------------------------------
@@ -63,6 +64,8 @@ ADDR               NAME
       0xffffa08953aac000 HEALTHY NONE      /tmp/dks0
       0xffffa08953ab0000 HEALTHY NONE      /tmp/dks1
       0xffffa08953ab4000 HEALTHY NONE      /tmp/dks2
+      -                  -       -     cache
+      0xffffa088ce7d0000 HEALTHY NONE    /tmp/dks3
 0xffffa08955c44000 rpool
       ADDR               STATE   AUX  DESCRIPTION
       ------------------------------------------------------------

--- a/tests/integration/data/regression_output/zfs/spa -vmH
+++ b/tests/integration/data/regression_output/zfs/spa -vmH
@@ -413,6 +413,7 @@ ADDR               NAME
                Approx. Median: 192.0MB
       0xffffa08948af8000 HEALTHY NONE      /dev/sdb1
       0xffffa08949ff8000 HEALTHY NONE      /dev/sdc1
+      -                  -       -     logs
       0xffffa08949e58000 HEALTHY NONE    /dev/sdd1
           ** No histogram data available **
            ADDR                 ID           OFFSET     FREE  FRAG     UCMU
@@ -582,6 +583,8 @@ ADDR               NAME
       0xffffa08953aac000 HEALTHY NONE      /tmp/dks0
       0xffffa08953ab0000 HEALTHY NONE      /tmp/dks1
       0xffffa08953ab4000 HEALTHY NONE      /tmp/dks2
+      -                  -       -     cache
+      0xffffa088ce7d0000 HEALTHY NONE    /tmp/dks3
 0xffffa08955c44000 rpool
      ** No histogram data available **
       ADDR               STATE   AUX  DESCRIPTION

--- a/tests/integration/data/regression_output/zfs/spa | vdev
+++ b/tests/integration/data/regression_output/zfs/spa | vdev
@@ -4,11 +4,14 @@
  0xffffa08949ff4000 HEALTHY NONE    mirror
  0xffffa08948af8000 HEALTHY NONE      /dev/sdb1
  0xffffa08949ff8000 HEALTHY NONE      /dev/sdc1
+ -                  -       -     logs
  0xffffa08949e58000 HEALTHY NONE    /dev/sdd1
  0xffffa08953aa4000 HEALTHY NONE  root
  0xffffa08953aa8000 HEALTHY NONE    raidz
  0xffffa08953aac000 HEALTHY NONE      /tmp/dks0
  0xffffa08953ab0000 HEALTHY NONE      /tmp/dks1
  0xffffa08953ab4000 HEALTHY NONE      /tmp/dks2
+ -                  -       -     cache
+ 0xffffa088ce7d0000 HEALTHY NONE    /tmp/dks3
  0xffffa08952efc000 HEALTHY NONE  root
  0xffffa08953300000 HEALTHY NONE    /dev/sda1

--- a/tests/integration/data/regression_output/zfs/spa | vdev | pp
+++ b/tests/integration/data/regression_output/zfs/spa | vdev | pp
@@ -4,11 +4,14 @@
  0xffffa08949ff4000 HEALTHY NONE    mirror
  0xffffa08948af8000 HEALTHY NONE      /dev/sdb1
  0xffffa08949ff8000 HEALTHY NONE      /dev/sdc1
+ -                  -       -     logs
  0xffffa08949e58000 HEALTHY NONE    /dev/sdd1
  0xffffa08953aa4000 HEALTHY NONE  root
  0xffffa08953aa8000 HEALTHY NONE    raidz
  0xffffa08953aac000 HEALTHY NONE      /tmp/dks0
  0xffffa08953ab0000 HEALTHY NONE      /tmp/dks1
  0xffffa08953ab4000 HEALTHY NONE      /tmp/dks2
+ -                  -       -     cache
+ 0xffffa088ce7d0000 HEALTHY NONE    /tmp/dks3
  0xffffa08952efc000 HEALTHY NONE  root
  0xffffa08953300000 HEALTHY NONE    /dev/sda1


### PR DESCRIPTION
Show cache devices in spa -v output
Fixes #114

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build was run locally and any changes were pushed
- [ ] Lint has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
spa -v does not list cache vdev

Issue Number: 114


## What is the new behavior?
```
root@ub-20:~/sdb# zpool status
  pool: tank
 state: ONLINE
config:

	NAME           STATE     READ WRITE CKSUM
	tank           ONLINE       0     0     0
	  /root/file1  ONLINE       0     0     0
	logs	
	  /root/file4  ONLINE       0     0     0
	cache
	  /root/file2  ONLINE       0     0     0
	spares
	  /root/file3  AVAIL   

errors: No known data errors
root@ub-20:~/sdb# sdb
sdb: could not get debugging information for:
/usr/lib/modules/5.4.0-52-generic/misc/vboxguest.ko (libdwfl error: No DWARF information found)
/usr/lib/modules/5.4.0-52-generic/misc/vboxvideo.ko (libdwfl error: No DWARF information found)
sdb> spa -v
ADDR               NAME
------------------------------------------------------------
0xffff88ff177f4000 tank
      ADDR               STATE   AUX  DESCRIPTION
      ------------------------------------------------------------
      0xffff88ff1d788000 HEALTHY NONE  root
      0xffff88ff1d7a0000 HEALTHY NONE    /root/file1
      0xffff88ff1d6cc000 HEALTHY NONE    /root/file4
      0xffff88ff1d628000 HEALTHY NONE  /root/file2      <== previously this was not shown
sdb> 
```
-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
