### PR TITLE
gh-actions: always update apt repos before installing packages

### DIFF
--- a/.github/scripts/install-drgn.sh
+++ b/.github/scripts/install-drgn.sh
@@ -4,7 +4,8 @@
 # These are build requirements of "drgn"; if we don't install these, the
 # build/install of "drgn" will fail below.
 #
-sudo apt-get install bison flex libelf-dev libdw-dev libomp5 libomp-dev
+sudo apt update
+sudo apt install bison flex libelf-dev libdw-dev libomp5 libomp-dev
 
 git clone https://github.com/osandov/drgn.git
 

--- a/.github/scripts/install-libkdumpfile.sh
+++ b/.github/scripts/install-libkdumpfile.sh
@@ -6,8 +6,9 @@
 # all version of python3.X-dev so the Github actions jobs can install
 # libkdumpfile with the right version.
 #
-sudo apt-get install autoconf automake liblzo2-dev libsnappy1v5 libtool pkg-config zlib1g-dev
-sudo apt-get install python3.6-dev python3.7-dev python3.8-dev
+sudo apt update
+sudo apt install autoconf automake liblzo2-dev libsnappy1v5 libtool pkg-config zlib1g-dev
+sudo apt install python3.6-dev python3.7-dev python3.8-dev
 
 git clone https://github.com/ptesarik/libkdumpfile.git
 


### PR DESCRIPTION
Some jobs have been failing recently because the local Azure repos
in the containers that our actions run were out of date and missing
packages.