### PR TITLE
Replace current PR template on Github

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+[//]: # (This PR template outlines different sections that you can fill so reviewers have an easier time understanding your review.)
+[//]: # (Using this template is strongly encouraged but not a hard requirement for getting your PR merged.)
+[//]: # (Using this template in your commit description is also encouraged.)
+
+= Problem
+
+[//]: # (A clear description of the problem. The problem statement should be written in terms of a specific symptom that affects users or the codebase.)
+[//]: # (The problem statement should not be written in terms of the solution.)
+
+= Solution
+
+[//]: # (A clear description of the high-level solution you have chosen and the reasons behind it.)
+[//]: # (Describing why you chose the specific solution here is just as important as the actual high-level description of the solution.)
+[//]: # (If there were other possible solutions that you considered and rejected, please mention those as well and the reasons you rejected them.)
+
+
+[//]: # (Extra Possible Sections:)
+
+[//]: # (= Notes To Reviewers)
+
+[//]: # (Any extra information a reviewer may need to know before reviewing your change.)
+[//]: # (For example here you might want to describe which files should be looked at first or which files.)
+
+[//]: # (= Future work)
+
+[//]: # (A description of what follow up work is explicitly not being done in this change.)
+[//]: # (Creating new issues for that future work in the repo tracker and mentioning them here may work as well.)
+
+[//]: # (= Testing)
+
+[//]: # (If your patch introduces changes that are not covered by our CI/CD checks, please describe how you did your testing.)
+
+[//]: # (= Github Issue Tracker Automation)
+
+[//]: # (If your patch is fixing an issue filled in the repo's issue tracker mention this here. Example: "Closes #56")


### PR DESCRIPTION
= Problem
The default PR template that we inherit from the Delphix Github
organization is too generic and some of its fields are not applicable
to SDB.

= Solution
This patch introduces a new template that is more suitable for our
needs.

= Notes To Reviewers
The choice of using `=` instead of `#` (Markdown Header) for
the template sections is for the case that the submitter decides
to copy paste the template in their commit description in git.
The `#` character is used for comments in git descriptions so
these section headers would disappear once the commit description
is written.

= Testing
I've opened the following test PR where I verify that I can still see
the comments in the PR description when creating or editing it:
https://github.com/sdimitro/sdb/pull/4