### PR TITLE
Fix Current Pylint Errors

### DIFF
--- a/sdb/commands/zfs/histograms.py
+++ b/sdb/commands/zfs/histograms.py
@@ -133,8 +133,7 @@ class ZFSHistogram(sdb.Command):
                 max_count = count
 
         HISTOGRAM_WIDTH_MAX = 40
-        if max_count < HISTOGRAM_WIDTH_MAX:
-            max_count = HISTOGRAM_WIDTH_MAX
+        max_count = max(max_count, HISTOGRAM_WIDTH_MAX)
 
         if min_bucket > max_bucket:
             print(f'{" " * indent}** No histogram data available **')

--- a/sdb/pipeline.py
+++ b/sdb/pipeline.py
@@ -129,6 +129,12 @@ def invoke(myprog: drgn.Program, first_input: Iterable[drgn.Object],
     # at the end.
     #
     if shell_cmd is not None:
+        #
+        # This is a false-positive from pylint as we need
+        # to explicitly wait for shell_proc to be done and
+        # re-arrange our std_out.
+        #
+        # pylint: disable=consider-using-with
         shell_proc = subprocess.Popen(shell_cmd,
                                       shell=True,
                                       stdin=subprocess.PIPE,


### PR DESCRIPTION
= Before The Patch

We'd get the following error from our `pylint` action:
```
************* Module sdb.pipeline
sdb/pipeline.py:132:8: R1732: Consider using 'with' for resource-allocating operations (consider-using-with)
************* Module sdb.commands.zfs.histograms
sdb/commands/zfs/histograms.py:136:8: R1731: Consider using 'max_count = max(max_count, HISTOGRAM_WIDTH_MAX)' instead of unnecessary if block (consider-using-max-builtin)
```

= After the Patch

Pylint runs fine with no errors