### PR TITLE
Walker should coerce types

### DIFF
--- a/sdb/command.py
+++ b/sdb/command.py
@@ -600,6 +600,11 @@ class Walk(Command):
         has_input = False
         for i in objs:
             has_input = True
+            obj_type = type_canonicalize(i.type_)
+            # if type is foo_t change to foo_t *
+            if obj_type.kind != drgn.TypeKind.POINTER:
+                i = target.create_object(target.get_pointer_type(obj_type),
+                                         i.address_)
             this_type_name = type_canonical_name(i.type_)
             if this_type_name not in baked:
                 raise CommandError(self.name, Walk._help_message(i.type_))

--- a/tests/integration/data/regression_output/core/spa | member spa_config_list | walk
+++ b/tests/integration/data/regression_output/core/spa | member spa_config_list | walk
@@ -1,0 +1,3 @@
+(void *)0xffffa08954d6a480
+(void *)0xffffa089481ade80
+(void *)0xffffa0895339bb20

--- a/tests/integration/test_core_generic.py
+++ b/tests/integration/test_core_generic.py
@@ -133,6 +133,9 @@ POS_CMDS = [
     "spa | vdev | metaslab | deref | sizeof | sum",
     "threads | sizeof | sum",
     "threads | deref | sizeof | sum",
+
+    # walker
+    "spa | member spa_config_list | walk",
 ]
 
 NEG_CMDS = [


### PR DESCRIPTION
If walker encounters a struct it should automatically convert
the object to a struct pointer instead of stopping.

= Problem

Walker fails when encountering a struct because it is expecting a struct pointer.

= Solution

Have the walker detect when an object is not a pointer, and convert it to a pointer automatically.

[//]: # (Extra Possible Sections:)

[//]: # (= Notes To Reviewers)

[//]: # (Any extra information a reviewer may need to know before reviewing your change.)
[//]: # (For example here you might want to describe which files should be looked at first or which files.)

[//]: # (= Future work)

[//]: # (A description of what follow up work is explicitly not being done in this change.)
[//]: # (Creating new issues for that future work in the repo tracker and mentioning them here may work as well.)

[//]: # (= Testing)
Added a test case for
spa | member spa_config_list | walk
which now works.

[//]: # (If your patch introduces changes that are not covered by our CI/CD checks, please describe how you did your testing.)

[//]: # (= Github Issue Tracker Automation)

Closes #193 