### PR TITLE
Fix Regressions

### DIFF
--- a/sdb/command.py
+++ b/sdb/command.py
@@ -587,9 +587,9 @@ class Walk(Command):
         if input_type is not None:
             msg += f"no walker found for input of type {input_type}\n"
         msg += "The following types have walkers:\n"
-        msg += f"\t{'WALKER':-20s} {'TYPE':-20s}\n"
+        msg += f"\t{'WALKER':<20s} {'TYPE':<20s}\n"
         for type_, class_ in Walker.allWalkers.items():
-            msg += f"\t{class_.names[0]:-20s} {type_:-20s}\n"
+            msg += f"\t{class_.names[0]:<20s} {type_:<20s}\n"
         return msg
 
     def _call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:

--- a/sdb/commands/linux/process.py
+++ b/sdb/commands/linux/process.py
@@ -22,6 +22,8 @@ from typing import Iterable
 import drgn
 import sdb
 
+from drgn.helpers.linux.pid import find_pid, find_task
+
 
 class FindPid(sdb.Command):
     """
@@ -56,7 +58,7 @@ class FindPid(sdb.Command):
 
     def _call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
         for pid in self.args.pid:
-            yield drgn.helpers.linux.pid.find_pid(sdb.get_prog(), pid)
+            yield find_pid(sdb.get_prog(), pid)
 
 
 class FindTask(sdb.Command):
@@ -87,4 +89,4 @@ class FindTask(sdb.Command):
 
     def _call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
         for pid in self.args.pid:
-            yield drgn.helpers.linux.pid.find_task(sdb.get_prog(), pid)
+            yield find_task(sdb.get_prog(), pid)

--- a/sdb/commands/spl/spl_kmem_caches.py
+++ b/sdb/commands/spl/spl_kmem_caches.py
@@ -212,7 +212,7 @@ class SplKmemCacheWalker(sdb.Walker):
     EXAMPLES
         Print all the objects in the ddt_cache:
 
-            sdb> spl_kmem_caches | filter obj.skc_name == "ddt_cache" | spl_cache
+            sdb> spl_kmem_caches | filter 'obj.skc_name == "ddt_cache"' | spl_cache
             (void *)0xffffa08937e80040
             (void *)0xffffa08937e86180
             (void *)0xffffa08937e8c2c0

--- a/sdb/commands/zfs/btree.py
+++ b/sdb/commands/zfs/btree.py
@@ -66,8 +66,17 @@ class Btree(sdb.Walker):
         if not node:
             return
 
+        #
+        # We check both members of the node because of the change introdcued in
+        # https://github.com/delphix/zfs/commit/c0bf952c846100750f526c2a32ebec17694a201b
+        #
+        try:
+            recurse = int(node.bth_first) == -1
+        except AttributeError:
+            recurse = node.bth_core
+
         count = node.bth_count
-        if node.bth_core:
+        if recurse:
             # alterate recursive descent on the children and generating core objects
             core = drgn.cast('struct zfs_btree_core *', node)
             for i in range(count):


### PR DESCRIPTION
Commit 1:
```
[Fix Walk command message error](https://github.com/delphix/sdb/commit/981bea0c4850916790cad566cc495a8af90b5aac) 

= Testing

=```
sdb> walk
The following types have walkers:
	WALKER               TYPE
	spl_list             list_t *
	multilist            multilist_t *
	slub_cache           struct kmem_cache *
	spl_cache            spl_kmem_cache_t *
	avl                  avl_tree_t *
	zfs_btree            zfs_btree_t *
=```

= Github Issue Tracker Automation

Closes https://github.com/delphix/sdb/issues/296
```

Commit 2:
```
[Fix mypy errors](https://github.com/delphix/sdb/commit/b9062d2140176c1ba6195a2996a4cfd9f20030ab) 

Original Errors:
=```
sdb/commands/linux/process.py:59: error: Module has no attribute "find_pid"  [attr-defined]
sdb/commands/linux/process.py:90: error: Module has no attribute "find_task"  [attr-defined]
Found 2 errors in 1 file (checked 64 source files)
=```
```

Commit 3:
```
[Fix B-Tree Walker](https://github.com/delphix/sdb/pull/299/commits/916f23e4574cfdb8f64b333df8a65f160c279954) 

= Testing

Before:
=```
  File "/usr/lib/python3/dist-packages/sdb/command.py", line 651, in _call
    yield from self.walk(obj)
  File "/usr/lib/python3/dist-packages/sdb/commands/zfs/btree.py", line 86, in walk
    yield from self._helper(obj.bt_root)
  File "/usr/lib/python3/dist-packages/sdb/commands/zfs/btree.py", line 70, in _helper
    if node.bth_core:
AttributeError: 'zfs_btree_hdr_t' has no member 'bth_core'
----------------------------------------------------------
Link: https://github.com/delphix/sdb/issues/new
=```

After:
=```
sdb> spa | vdev 0 | metaslab | member ms_allocatable.rt_root | filter "obj.bt_num_elems != 0" | head 1 | zfs_btree
(void *)0xffff9cfb9a44a010
(void *)0xffff9cfb9a44a018
(void *)0xffff9cfb9a44a020
(void *)0xffff9cfb9a44a028
(void *)0xffff9cfb9a44a030
=```

= Github Issue Tracker Automation

Closes https://github.com/delphix/sdb/issues/297
```

Commit 4:
```
[Fix incorrect example in spl_cache](https://github.com/delphix/sdb/pull/299/commits/1f5021b7c9b91bb45d669cb73a10419ec681ca4b) 
[1f5021b](https://github.com/delphix/sdb/pull/299/commits/1f5021b7c9b91bb45d669cb73a10419ec681ca4b)
= Testing

=```
sdb> man spl_cache
SUMMARY
    spl_cache [-h]

...<cropped>...

EXAMPLES
    Print all the objects in the ddt_cache:

        sdb> spl_kmem_caches | filter 'obj.skc_name == "ddt_cache"' | spl_cache
        (void *)0xffffa08937e80040
        (void *)0xffffa08937e86180
        (void *)0xffffa08937e8c2c0
        (void *)0xffffa08937e92400
        ...
=```

= Github Issue Tracker Automation

Closes https://github.com/delphix/sdb/issues/295
```