### PR TITLE
Add Python 3.9 to Github Action Tests

### DIFF
--- a/.github/scripts/install-libkdumpfile.sh
+++ b/.github/scripts/install-libkdumpfile.sh
@@ -8,7 +8,7 @@
 #
 sudo apt update
 sudo apt install autoconf automake liblzo2-dev libsnappy1v5 libtool pkg-config zlib1g-dev
-sudo apt install python3.8-dev
+sudo apt install python3.8-dev python3.9-dev
 
 git clone https://github.com/ptesarik/libkdumpfile.git
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.8, 3.9]
     env:
       AWS_DEFAULT_REGION: 'us-west-2'
     steps:


### PR DESCRIPTION
We don't use Python 3.9 in the product but testing multiple versions ensures that sdb works properly for more people, plus it prepares us for the move to 22.04+.

= Github Issue Tracker Automation

Closes #265