### PR TITLE
DLPX-84437 Print panicked thread of crash dump on SDB

### DIFF
--- a/tests/integration/data/regression_output/dump.201912060006/linux/crashed_thread
+++ b/tests/integration/data/regression_output/dump.201912060006/linux/crashed_thread
@@ -1,0 +1,19 @@
+TASK_STRUCT        STATE             COUNT
+==========================================
+0xffffa08884831700 RUNNING               1
+                  __crash_kexec+0x9d
+                  __crash_kexec+0x9d
+                  panic+0x10e
+                  0xffffffff8b849f25+0x0
+                  __handle_sysrq+0x9f
+                  write_sysrq_trigger+0x34
+                  proc_reg_write+0x3e
+                  __vfs_write+0x1b
+                  vfs_write+0xb1
+                  ksys_write+0x5c
+                  __x64_sys_write+0x1a
+                  __x64_sys_write+0x1a
+                  __x64_sys_write+0x1a
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+

--- a/tests/integration/data/regression_output/dump.201912060006/linux/crashed_thread | stacks
+++ b/tests/integration/data/regression_output/dump.201912060006/linux/crashed_thread | stacks
@@ -1,0 +1,19 @@
+TASK_STRUCT        STATE             COUNT
+==========================================
+0xffffa08884831700 RUNNING               1
+                  __crash_kexec+0x9d
+                  __crash_kexec+0x9d
+                  panic+0x10e
+                  0xffffffff8b849f25+0x0
+                  __handle_sysrq+0x9f
+                  write_sysrq_trigger+0x34
+                  proc_reg_write+0x3e
+                  __vfs_write+0x1b
+                  vfs_write+0xb1
+                  ksys_write+0x5c
+                  __x64_sys_write+0x1a
+                  __x64_sys_write+0x1a
+                  __x64_sys_write+0x1a
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+

--- a/tests/integration/test_linux_generic.py
+++ b/tests/integration/test_linux_generic.py
@@ -33,6 +33,10 @@ POS_CMDS = [
     "addr tcp_orphan_count | cpu_counter_sum",
     "addr tcp_sockets_allocated | cpu_counter_sum",
 
+    # crashed_thread
+    "crashed_thread",
+    "crashed_thread | stacks",
+
     # percpu
     'slabs | filter \'obj.name == "kmalloc-8"\' | member cpu_slab | percpu',
     'slabs | filter \'obj.name == "kmalloc-8"\' | member cpu_slab | percpu 0',


### PR DESCRIPTION
= Motivation

The `stacks` command can be overwhelming for newcomers that need to
figure out which thread caused the debugging target to panic. An
alternative would be `dmesg`, but that command also has a lot of
extraneous output.

= This Patch

Creates a new SDB command that yields the panicked thread to subsequent
commands or just pretty-prints it in the style of the `stacks` command.

= Example Output

```
sdb> crashed_thread
TASK_STRUCT        STATE             COUNT
==========================================
0xffff8f15d7333d00 RUNNING               1
	      __crash_kexec+0x9d
	      __crash_kexec+0x9d
	      panic+0x11d
	      0xffffffff9020b375+0x0
	      __handle_sysrq.cold+0x48
	      write_sysrq_trigger+0x28
	      proc_reg_write+0x43
	      __vfs_write+0x1b
	      vfs_write+0xb9
	      vfs_write+0xb9
	      ksys_write+0x67
	      __x64_sys_write+0x1a
	      __x64_sys_write+0x1a
	      __x64_sys_write+0x1a
	      do_syscall_64+0x57
	      entry_SYSCALL_64+0x94
```

Error case A: Live-Target:
```
$ sudo sdb
sdb> crashed_thread
sdb: crashed_thread: command only works for core/crash dumps
```

Error case B: Pretty-print bogus thread/value:
```
sdb> stacks | head 1 | crashed_thread
sdb: crashed_thread: can only pretty print the crashed thread
sdb> echo 0x0 | crashed_thread
sdb: crashed_thread: can only pretty print the crashed thread
```