### PR TITLE
DLPX-84520 Fix SDB pylint error in histogram.py

### DIFF
--- a/sdb/commands/zfs/histograms.py
+++ b/sdb/commands/zfs/histograms.py
@@ -121,7 +121,7 @@ class ZFSHistogram(sdb.Command):
             canonical_type.type).kind == drgn.TypeKind.INT
 
         max_count = 0
-        min_bucket = (len(hist) - 1)
+        min_bucket = len(hist) - 1
         max_bucket = 0
         for (bucket, value) in enumerate(hist):
             count = int(value)


### PR DESCRIPTION
This is to unblock the nightlies

Here is the pylint error from https://github.com/delphix/sdb/actions/runs/4079788362/jobs/7031524649:
```
************* Module sdb.commands.zfs.histograms
sdb/commands/zfs/histograms.py:124:0: C0325: Unnecessary parens after '=' keyword (superfluous-parens)
```