### PR TITLE
Update btree walker to be aware of btree optimizations

### DIFF
--- a/sdb/commands/zfs/btree.py
+++ b/sdb/commands/zfs/btree.py
@@ -88,7 +88,7 @@ class Btree(sdb.Walker):
             # generate each object in the leaf elements
             leaf = drgn.cast('struct zfs_btree_leaf *', node)
             for i in range(count):
-                yield self._val(leaf.btl_elems, i)
+                yield self._val(leaf.btl_elems, i + node.bth_first)
 
     def walk(self, obj: drgn.Object) -> Iterable[drgn.Object]:
         self.elem_size = obj.bt_elem_size


### PR DESCRIPTION
[//]: # (This PR template outlines different sections that you can fill so reviewers have an easier time understanding your review.)
[//]: # (Using this template is strongly encouraged but not a hard requirement for getting your PR merged.)
[//]: # (Using this template in your commit description is also encouraged.)

= Problem
ZFS's btrees were recently optimized to improve performance. One of the changes modified the in memory structure by adding a first-element offset for leaf nodes, allowing a reduction in memmove calls and sizes.

= Solution
Update the btree walker to be aware of this new behavior
