### PR TITLE
Update btree walker to be aware of btree optimizations

### DIFF
--- a/sdb/commands/zfs/btree.py
+++ b/sdb/commands/zfs/btree.py
@@ -71,8 +71,10 @@ class Btree(sdb.Walker):
         # https://github.com/delphix/zfs/commit/c0bf952c846100750f526c2a32ebec17694a201b
         #
         try:
-            recurse = int(node.bth_first) == -1
+            bth_first = node.bth_first
+            recurse = int(bth_first) == -1
         except AttributeError:
+            bth_first = 0
             recurse = node.bth_core
 
         count = node.bth_count
@@ -88,7 +90,7 @@ class Btree(sdb.Walker):
             # generate each object in the leaf elements
             leaf = drgn.cast('struct zfs_btree_leaf *', node)
             for i in range(count):
-                yield self._val(leaf.btl_elems, i)
+                yield self._val(leaf.btl_elems, i + bth_first)
 
     def walk(self, obj: drgn.Object) -> Iterable[drgn.Object]:
         self.elem_size = obj.bt_elem_size


### PR DESCRIPTION
= Problem
ZFS's btrees were recently optimized to improve performance. One of the changes modified the in memory structure by adding a first-element offset for leaf nodes, allowing a reduction in memmove calls and sizes.

= Solution
Update the btree walker to be aware of this new behavior

PR Re-created because you can't modify PRs that are coming from internal branches, for some reason, and the branch is protected so I couldn't push commits to it.