### PR TITLE
DLPX-85135 Use new Delphix S3 bucket for reference crash dumps

### DIFF
--- a/.github/scripts/download-dump-from-s3.sh
+++ b/.github/scripts/download-dump-from-s3.sh
@@ -28,7 +28,7 @@ if [ ! -d $DATA_DIR ]; then
 fi
 
 echo "initiating download of $1 from S3 ..."
-/usr/local/bin/aws s3 cp --no-sign-request s3://sdb-regression-dumps/$1 .
+wget https://sdb-testing-bucket.s3.us-west-2.amazonaws.com/$1
 [ $? -eq 0 ] || exit 1
 
 if [[ $1 == *.lzma ]]; then


### PR DESCRIPTION
Our previous s3 bucket was managed by OpenZFS which is its own community. Since SDB is primarily developed and used by Delphix developers it makes sense to host our reference crash dumps on our own bucket. This should also give us more flexibility in adding crash dumps more often and staying ahead of regressions more easily.

# Testing

If the tests pass it works :)