### PR TITLE
DLPX-85140 SDB blows up in zero-length arrays

### DIFF
--- a/sdb/command.py
+++ b/sdb/command.py
@@ -287,6 +287,16 @@ class Command:
         for obj in objs:
             try:
                 obj.read_()
+            except TypeError as err:
+                obj_type = type_canonicalize(obj.type_)
+                if obj_type.kind == drgn.TypeKind.ARRAY and not obj_type.is_complete(
+                ) and not obj.absent_:
+                    #
+                    # This is a zero-length array, let it go through.
+                    #
+                    yield obj
+                    continue
+                raise err
             except drgn.FaultError as err:
                 if obj.address_ is None:
                     #

--- a/sdb/commands/array.py
+++ b/sdb/commands/array.py
@@ -86,7 +86,14 @@ class Array(sdb.SingleInputCommand):
         nelems = 0
 
         obj_type = sdb.type_canonicalize(obj.type_)
-        if obj_type.kind == drgn.TypeKind.ARRAY:
+        if obj_type.kind == drgn.TypeKind.ARRAY and not obj_type.is_complete(
+        ) and not obj.absent_:
+            if self.args.nelems is None:
+                err_msg = "zero-length array: please specify number of elements"
+                raise sdb.CommandError(self.name, err_msg)
+            print("warning: operating on zero-length array")
+            nelems = self.args.nelems
+        elif obj_type.kind == drgn.TypeKind.ARRAY:
             array_elems = len(obj)
             if self.args.nelems is not None:
                 nelems = self.args.nelems

--- a/sdb/commands/member.py
+++ b/sdb/commands/member.py
@@ -272,7 +272,7 @@ class Member(sdb.SingleInputCommand):
         if base_kind == drgn.TypeKind.POINTER:
             return
         assert base_kind == drgn.TypeKind.ARRAY
-        if type_.length <= idx:
+        if type_.length is None or type_.length <= idx:
             warn_msg = f"index out of bounds for array of type '{type_}' (requested index: {idx})"
             print(f"warning: {self.name}: {warn_msg}")
 


### PR DESCRIPTION
Zero-length arrays were partially supported in SDB with the scenarios that aren't supported blowing up the SDB session. Even though that was rare it now occurs more often as more code uses the C99 flexible array notation. An example is the following commit in the ZFS kernel module:

https://github.com/delphix/zfs/commit/9c8fabffa2b15a4ada570c8c469ff0709d00b003

This patch provides support for those arrays while also warning the user that they may print garbage values if we pass their implicit size.

I came across this failure while generating the test results for our new reference crash dump. Fixing this issue will be the last obstacle in generating new regression tests.

= Testing

Before:
```
$ sudo sdb -e 'zfs_dbgmsg | head 1 | member zdm_msg[2]'
sdb encountered an internal error due to a bug. Here's the
information you need to file the bug:
----------------------------------------------------------
Target Info:
	ProgramFlags.IS_LIVE|IS_LINUX_KERNEL
	Platform(<Architecture.X86_64: 1>, <PlatformFlags.IS_LITTLE_ENDIAN|IS_64_BIT: 3>)

Traceback (most recent call last):
...snip...
  File "/usr/lib/python3/dist-packages/sdb/commands/member.py", line 275, in _validate_array_index
    if type_.length <= idx:
TypeError: '<=' not supported between instances of 'NoneType' and 'int'
----------------------------------------------------------
Link: https://github.com/delphix/sdb/issues/new

$ sudo sdb -e 'zfs_dbgmsg | head 1 | member zdm_msg | array'
Target Info:
	ProgramFlags.IS_LIVE|IS_LINUX_KERNEL
	Platform(<Architecture.X86_64: 1>, <PlatformFlags.IS_LITTLE_ENDIAN|IS_64_BIT: 3>)

Traceback (most recent call last):
...snip...
  File "/usr/lib/python3/dist-packages/sdb/command.py", line 289, in __invalid_memory_objects_check
    obj.read_()
TypeError: cannot read object with incomplete array type
----------------------------------------------------------
Link: https://github.com/delphix/sdb/issues/new

$ sudo sdb -e 'zfs_dbgmsg | head 1 | member zdm_msg | array 1'
Target Info:
	ProgramFlags.IS_LIVE|IS_LINUX_KERNEL
	Platform(<Architecture.X86_64: 1>, <PlatformFlags.IS_LITTLE_ENDIAN|IS_64_BIT: 3>)

Traceback (most recent call last):
...snip...
  File "/usr/lib/python3/dist-packages/sdb/command.py", line 289, in __invalid_memory_objects_check
    obj.read_()
TypeError: cannot read object with incomplete array type
----------------------------------------------------------
Link: https://github.com/delphix/sdb/issues/new
```

After this patch:
```
$ sudo sdb -e 'zfs_dbgmsg | head 1 | member zdm_msg[2]'
warning: member: index out of bounds for array of type 'char []' (requested index: 2)
(char)97

$ sudo sdb -e 'zfs_dbgmsg | head 1 | member zdm_msg | array'
sdb: array: zero-length array: please specify number of elements

$ sudo sdb -e 'zfs_dbgmsg | head 1 | member zdm_msg | array 1'
warning: operating on zero-length array
(char)115

$ sudo sdb -e 'zfs_dbgmsg | head 1 | member zdm_msg | array 3'
warning: operating on zero-length array
(char)115
(char)112
(char)97
```