### PR TITLE
Add module system to prevent commands from being loaded when they aren't useful

### DIFF
--- a/sdb/__init__.py
+++ b/sdb/__init__.py
@@ -36,14 +36,15 @@ from sdb.target import (create_object, get_object, get_prog, get_type,
                         get_pointer_type, get_target_flags, get_symbol, is_null,
                         type_canonical_name, type_canonicalize,
                         type_canonicalize_name, type_canonicalize_size,
-                        type_equals)
+                        type_equals, Runtime, All, Kernel, Userland, Module, Library)
 from sdb.command import (Address, Cast, Command, InputHandler, Locator,
                          PrettyPrinter, Walk, Walker, SingleInputCommand,
-                         get_registered_commands)
+                         get_registered_commands, register_commands)
 from sdb.pipeline import execute_pipeline, get_first_type, invoke
 
 __all__ = [
     'Address',
+    'All',
     'Cast',
     'Command',
     'CommandArgumentsError',
@@ -53,11 +54,16 @@ __all__ = [
     'CommandNotFoundError',
     'Error',
     'InputHandler',
+    'Kernel',
+    'Library',
     'Locator',
+    'Module',
     'ParserError',
     'PrettyPrinter',
+    'Runtime',
     'SingleInputCommand',
     'SymbolNotFoundError',
+    'Userland',
     'Walk',
     'Walker',
     'create_object',
@@ -72,6 +78,7 @@ __all__ = [
     'get_symbol',
     'get_target_flags',
     'get_type',
+    'register_commands',
     'type_canonical_name',
     'type_canonicalize',
     'type_canonicalize_name',

--- a/sdb/__init__.py
+++ b/sdb/__init__.py
@@ -36,7 +36,8 @@ from sdb.target import (create_object, get_object, get_prog, get_type,
                         get_pointer_type, get_target_flags, get_symbol, is_null,
                         type_canonical_name, type_canonicalize,
                         type_canonicalize_name, type_canonicalize_size,
-                        type_equals, Runtime, All, Kernel, Userland, Module, Library)
+                        type_equals, Runtime, All, Kernel, Userland, Module,
+                        Library)
 from sdb.command import (Address, Cast, Command, InputHandler, Locator,
                          PrettyPrinter, Walk, Walker, SingleInputCommand,
                          get_registered_commands, register_commands)

--- a/sdb/commands/array.py
+++ b/sdb/commands/array.py
@@ -72,6 +72,7 @@ class Array(sdb.SingleInputCommand):
     """
 
     names = ["array"]
+    load_on = [sdb.All()]
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:

--- a/sdb/commands/container_of.py
+++ b/sdb/commands/container_of.py
@@ -46,6 +46,7 @@ class ContainerOf(sdb.Command):
     """
 
     names = ["container_of"]
+    load_on = [sdb.All()]
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:

--- a/sdb/commands/count.py
+++ b/sdb/commands/count.py
@@ -51,6 +51,7 @@ class Count(sdb.Command):
     """
 
     names = ["count", "cnt", "wc"]
+    load_on = [sdb.All()]
 
     def _call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
         yield sdb.create_object('unsigned long long', sum(1 for _ in objs))

--- a/sdb/commands/echo.py
+++ b/sdb/commands/echo.py
@@ -29,6 +29,7 @@ class Echo(sdb.Command):
     """
 
     names = ["echo", "cc"]
+    load_on = [sdb.All()]
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:

--- a/sdb/commands/exit.py
+++ b/sdb/commands/exit.py
@@ -26,6 +26,7 @@ class Exit(sdb.Command):
     "Exit the application"
 
     names = ["exit", "quit"]
+    load_on = [sdb.All()]
 
     def _call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
         raise SystemExit

--- a/sdb/commands/filter.py
+++ b/sdb/commands/filter.py
@@ -48,6 +48,7 @@ class Filter(sdb.SingleInputCommand):
     # pylint: disable=eval-used
 
     names = ["filter"]
+    load_on = [sdb.All()]
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:

--- a/sdb/commands/head.py
+++ b/sdb/commands/head.py
@@ -35,6 +35,7 @@ class Head(sdb.Command):
     """
 
     names = ["head"]
+    load_on = [sdb.All()]
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:

--- a/sdb/commands/help.py
+++ b/sdb/commands/help.py
@@ -27,6 +27,7 @@ class Help(sdb.Command):
     """ Displays help for the specified command for ex: help addr """
 
     names = ["help", "man"]
+    load_on = [sdb.All()]
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:

--- a/sdb/commands/history.py
+++ b/sdb/commands/history.py
@@ -31,6 +31,7 @@ class History(sdb.Command):
     # pylint: disable=too-few-public-methods
 
     names = ["history"]
+    load_on = [sdb.All()]
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:

--- a/sdb/commands/linux/dmesg.py
+++ b/sdb/commands/linux/dmesg.py
@@ -25,6 +25,7 @@ import sdb
 class DMesg(sdb.Locator, sdb.PrettyPrinter):
 
     names = ["dmesg"]
+    load_on = [sdb.Kernel()]
 
     input_type = "struct printk_log *"
     output_type = "struct printk_log *"

--- a/sdb/commands/linux/linked_lists.py
+++ b/sdb/commands/linux/linked_lists.py
@@ -63,6 +63,7 @@ class LxList(sdb.Command):
     """
 
     names = ["linux_list", "lxlist"]
+    load_on = [sdb.Kernel()]
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:

--- a/sdb/commands/linux/linked_lists.py
+++ b/sdb/commands/linux/linked_lists.py
@@ -107,6 +107,7 @@ class LxHList(sdb.Command):
     """
 
     names = ["linux_hlist", "lxhlist"]
+    load_on = [sdb.Kernel()]
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:

--- a/sdb/commands/linux/per_cpu.py
+++ b/sdb/commands/linux/per_cpu.py
@@ -95,6 +95,7 @@ class LxPerCpuCounterSum(sdb.SingleInputCommand):
 
     names = ["cpu_counter_sum"]
     input_type = "struct percpu_counter *"
+    load_on = [sdb.Kernel()]
 
     def _call_one(self, obj: drgn.Object) -> Iterable[drgn.Object]:
         try:

--- a/sdb/commands/linux/per_cpu.py
+++ b/sdb/commands/linux/per_cpu.py
@@ -44,6 +44,7 @@ class LxPerCpuPtr(sdb.SingleInputCommand):
     """
 
     names = ["percpu"]
+    load_on = [sdb.Kernel()]
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:

--- a/sdb/commands/linux/process.py
+++ b/sdb/commands/linux/process.py
@@ -77,6 +77,7 @@ class FindTask(sdb.Command):
     """
 
     names = ["find_task"]
+    load_on = [sdb.Kernel()]
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:

--- a/sdb/commands/linux/process.py
+++ b/sdb/commands/linux/process.py
@@ -45,6 +45,7 @@ class FindPid(sdb.Command):
     """
 
     names = ["pid"]
+    load_on = [sdb.Kernel()]
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:

--- a/sdb/commands/linux/slabs.py
+++ b/sdb/commands/linux/slabs.py
@@ -37,6 +37,7 @@ from sdb.commands.linux.internal import slub_helpers as slub
 class Slabs(sdb.Locator, sdb.PrettyPrinter):
 
     names = ["slabs"]
+    load_on = [sdb.Kernel()]
 
     input_type = "struct kmem_cache *"
     output_type = "struct kmem_cache *"

--- a/sdb/commands/linux/slabs.py
+++ b/sdb/commands/linux/slabs.py
@@ -241,6 +241,7 @@ class SlubCacheWalker(sdb.Walker):
 
     names = ["slub_cache"]
     input_type = "struct kmem_cache *"
+    load_on = [sdb.Kernel()]
 
     def walk(self, obj: drgn.Object) -> Iterable[drgn.Object]:
         yield from slab_cache_for_each_allocated_object(obj, "void")

--- a/sdb/commands/linux/stacks.py
+++ b/sdb/commands/linux/stacks.py
@@ -218,7 +218,8 @@ class KernelStacks(sdb.Locator, sdb.PrettyPrinter):
     def resolve_state(tstate: str) -> str:
         tstate = tstate.upper()
         if tstate in KernelStacks.TASK_STATE_SHORTCUTS:
-            return KernelStacks.TASK_STATES[KernelStacks.TASK_STATE_SHORTCUTS[tstate]]
+            return KernelStacks.TASK_STATES[
+                KernelStacks.TASK_STATE_SHORTCUTS[tstate]]
         return tstate
 
     @staticmethod
@@ -315,7 +316,8 @@ class KernelStacks(sdb.Locator, sdb.PrettyPrinter):
                     f" (acceptable states: {valid_states})")
 
         if self.args.module:
-            if KernelStacks.find_module_memory_segment(self.args.module)[0] == -1:
+            if KernelStacks.find_module_memory_segment(
+                    self.args.module)[0] == -1:
                 raise sdb.CommandError(
                     self.name,
                     f"module '{self.args.module}' doesn't exist or isn't currently loaded"

--- a/sdb/commands/linux/stacks.py
+++ b/sdb/commands/linux/stacks.py
@@ -27,7 +27,7 @@ from drgn.helpers.linux.pid import for_each_task
 import sdb
 
 
-class Stacks(sdb.Locator, sdb.PrettyPrinter):
+class KernelStacks(sdb.Locator, sdb.PrettyPrinter):
     """
     Print the stack traces for active threads (task_struct)
 
@@ -142,6 +142,7 @@ class Stacks(sdb.Locator, sdb.PrettyPrinter):
     names = ["stacks", "stack"]
     input_type = "struct task_struct *"
     output_type = "struct task_struct *"
+    load_on = [sdb.Kernel()]
 
     def __init__(self,
                  args: Optional[List[str]] = None,
@@ -173,7 +174,7 @@ class Stacks(sdb.Locator, sdb.PrettyPrinter):
             "-t",
             "--tstate",
             help="only print threads which are in TSTATE thread state")
-        parser.epilog = f'TSTATE := [{", ".join(Stacks.TASK_STATES.values()):s}]'
+        parser.epilog = f'TSTATE := [{", ".join(KernelStacks.TASK_STATES.values()):s}]'
         return parser
 
     #
@@ -211,13 +212,13 @@ class Stacks(sdb.Locator, sdb.PrettyPrinter):
             return "IDLE"
 
         exit_state = task.exit_state.value_()
-        return Stacks.TASK_STATES[(state | exit_state) & 0x7f]
+        return KernelStacks.TASK_STATES[(state | exit_state) & 0x7f]
 
     @staticmethod
     def resolve_state(tstate: str) -> str:
         tstate = tstate.upper()
-        if tstate in Stacks.TASK_STATE_SHORTCUTS:
-            return Stacks.TASK_STATES[Stacks.TASK_STATE_SHORTCUTS[tstate]]
+        if tstate in KernelStacks.TASK_STATE_SHORTCUTS:
+            return KernelStacks.TASK_STATES[KernelStacks.TASK_STATE_SHORTCUTS[tstate]]
         return tstate
 
     @staticmethod
@@ -305,8 +306,8 @@ class Stacks(sdb.Locator, sdb.PrettyPrinter):
             self.func_end = self.func_start + sym.size
 
         if self.args.tstate:
-            self.match_state = Stacks.resolve_state(self.args.tstate)
-            task_states = Stacks.TASK_STATES.values()
+            self.match_state = KernelStacks.resolve_state(self.args.tstate)
+            task_states = KernelStacks.TASK_STATES.values()
             if self.match_state not in task_states:
                 valid_states = ", ".join(task_states)
                 raise sdb.CommandError(
@@ -314,18 +315,18 @@ class Stacks(sdb.Locator, sdb.PrettyPrinter):
                     f" (acceptable states: {valid_states})")
 
         if self.args.module:
-            if Stacks.find_module_memory_segment(self.args.module)[0] == -1:
+            if KernelStacks.find_module_memory_segment(self.args.module)[0] == -1:
                 raise sdb.CommandError(
                     self.name,
                     f"module '{self.args.module}' doesn't exist or isn't currently loaded"
                 )
-            self.mod_start, mod_size = Stacks.find_module_memory_segment(
+            self.mod_start, mod_size = KernelStacks.find_module_memory_segment(
                 self.args.module)
             assert self.mod_start != -1
             self.mod_end = self.mod_start + mod_size
 
     def match_stack(self, task: drgn.Object) -> bool:
-        if self.args.tstate and self.match_state != Stacks.task_struct_get_state(
+        if self.args.tstate and self.match_state != KernelStacks.task_struct_get_state(
                 task):
             return False
 
@@ -333,7 +334,7 @@ class Stacks(sdb.Locator, sdb.PrettyPrinter):
             return True
 
         mod_match, func_match = not self.args.module, not self.args.function
-        for frame_pc in Stacks.get_frame_pcs(task):
+        for frame_pc in KernelStacks.get_frame_pcs(task):
             if not mod_match and self.mod_start <= frame_pc < self.mod_end:
                 mod_match = True
 
@@ -363,14 +364,14 @@ class Stacks(sdb.Locator, sdb.PrettyPrinter):
         stack_aggr: Dict[Tuple[str, Tuple[int, ...]],
                          List[drgn.Object]] = defaultdict(list)
         for task in objs:
-            stack_key = (Stacks.task_struct_get_state(task),
-                         tuple(Stacks.get_frame_pcs(task)))
+            stack_key = (KernelStacks.task_struct_get_state(task),
+                         tuple(KernelStacks.get_frame_pcs(task)))
             stack_aggr[stack_key].append(task)
         return sorted(stack_aggr.items(), key=lambda x: len(x[1]), reverse=True)
 
     def print_stacks(self, objs: Iterable[drgn.Object]) -> None:
         self.print_header()
-        for stack_key, tasks in Stacks.aggregate_stacks(objs):
+        for stack_key, tasks in KernelStacks.aggregate_stacks(objs):
             stacktrace_info = ""
             task_state = stack_key[0]
 
@@ -402,7 +403,7 @@ class Stacks(sdb.Locator, sdb.PrettyPrinter):
         yield from filter(self.match_stack, for_each_task(sdb.get_prog()))
 
 
-class CrashedThread(sdb.Locator, sdb.PrettyPrinter):
+class KernelCrashedThread(sdb.Locator, sdb.PrettyPrinter):
     """
     Print the crashed thread. Only works for crash dumps and core dumps.
 
@@ -432,6 +433,7 @@ class CrashedThread(sdb.Locator, sdb.PrettyPrinter):
     names = ["crashed_thread", "panic_stack", "panic_thread"]
     input_type = "struct task_struct *"
     output_type = "struct task_struct *"
+    load_on = [sdb.Kernel()]
 
     def validate_context(self) -> None:
         if sdb.get_target_flags() & drgn.ProgramFlags.IS_LIVE:
@@ -441,7 +443,7 @@ class CrashedThread(sdb.Locator, sdb.PrettyPrinter):
     def pretty_print(self, objs: Iterable[drgn.Object]) -> None:
         self.validate_context()
         thread_obj = sdb.get_prog().crashed_thread().object
-        stacks_obj = Stacks()
+        stacks_obj = KernelStacks()
         for obj in objs:
             if obj.value_() != thread_obj.value_():
                 raise sdb.CommandError(

--- a/sdb/commands/linux/threads.py
+++ b/sdb/commands/linux/threads.py
@@ -90,7 +90,9 @@ class KernelThreads(sdb.Locator, sdb.PrettyPrinter):
         fields = list(KernelThreads.FIELDS.keys())
         table = Table(fields, None, {"task": str})
         for obj in objs:
-            row_dict = {field: KernelThreads.FIELDS[field](obj) for field in fields}
+            row_dict = {
+                field: KernelThreads.FIELDS[field](obj) for field in fields
+            }
             table.add_row(row_dict["task"], row_dict)
         table.print_()
 

--- a/sdb/commands/linux/threads.py
+++ b/sdb/commands/linux/threads.py
@@ -25,7 +25,7 @@ from drgn.helpers.linux.mm import cmdline
 
 import sdb
 from sdb.commands.internal.table import Table
-from sdb.commands.stacks import Stacks
+from sdb.commands.linux.stacks import KernelStacks
 
 
 def _cmdline(obj: drgn.Object) -> str:
@@ -50,7 +50,7 @@ def _cmdline(obj: drgn.Object) -> str:
         return ""
 
 
-class Threads(sdb.Locator, sdb.PrettyPrinter):
+class KernelThreads(sdb.Locator, sdb.PrettyPrinter):
     """
     Locate and print information about threads (task_stuct)
 
@@ -75,10 +75,11 @@ class Threads(sdb.Locator, sdb.PrettyPrinter):
     names = ["threads", "thread"]
     input_type = "struct task_struct *"
     output_type = "struct task_struct *"
+    load_on = [sdb.Kernel()]
 
     FIELDS: Dict[str, Callable[[drgn.Object], Union[str, int]]] = {
         "task": lambda obj: hex(obj.value_()),
-        "state": lambda obj: str(Stacks.task_struct_get_state(obj)),
+        "state": lambda obj: str(KernelStacks.task_struct_get_state(obj)),
         "pid": lambda obj: int(obj.pid),
         "prio": lambda obj: int(obj.prio),
         "comm": lambda obj: str(obj.comm.string_().decode("utf-8")),
@@ -86,10 +87,10 @@ class Threads(sdb.Locator, sdb.PrettyPrinter):
     }
 
     def pretty_print(self, objs: Iterable[drgn.Object]) -> None:
-        fields = list(Threads.FIELDS.keys())
+        fields = list(KernelThreads.FIELDS.keys())
         table = Table(fields, None, {"task": str})
         for obj in objs:
-            row_dict = {field: Threads.FIELDS[field](obj) for field in fields}
+            row_dict = {field: KernelThreads.FIELDS[field](obj) for field in fields}
             table.add_row(row_dict["task"], row_dict)
         table.print_()
 

--- a/sdb/commands/linux/tree.py
+++ b/sdb/commands/linux/tree.py
@@ -47,6 +47,7 @@ class RBTree(sdb.Command):
     """
 
     names = ["rbtree"]
+    load_on = [sdb.Kernel()]
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:

--- a/sdb/commands/linux/vfs.py
+++ b/sdb/commands/linux/vfs.py
@@ -38,6 +38,7 @@ class FGet(sdb.SingleInputCommand):
 
     names = ["fget"]
     input_type = "struct task_struct *"
+    load_on = [sdb.Kernel()]
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:

--- a/sdb/commands/linux/whatis.py
+++ b/sdb/commands/linux/whatis.py
@@ -47,6 +47,7 @@ class WhatIs(sdb.Command):
     """
 
     names = ["whatis"]
+    load_on = [sdb.Kernel()]
 
     @staticmethod
     def print_cache(cache: drgn.Object, addr: str) -> None:

--- a/sdb/commands/member.py
+++ b/sdb/commands/member.py
@@ -119,6 +119,7 @@ class Member(sdb.SingleInputCommand):
     """
 
     names = ["member"]
+    load_on = [sdb.All()]
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:

--- a/sdb/commands/pretty_print.py
+++ b/sdb/commands/pretty_print.py
@@ -25,6 +25,7 @@ import sdb
 class PrettyPrint(sdb.Command):
 
     names = ["pretty_print", "pp"]
+    load_on = [sdb.All()]
 
     def _call(self, objs: Iterable[drgn.Object]) -> None:
         baked = {

--- a/sdb/commands/print.py
+++ b/sdb/commands/print.py
@@ -42,6 +42,7 @@ class Print(sdb.SingleInputCommand):
     """
 
     names = ["print"]
+    load_on = [sdb.All()]
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:

--- a/sdb/commands/ptype.py
+++ b/sdb/commands/ptype.py
@@ -66,6 +66,7 @@ class PType(sdb.Command):
     """
 
     names = ["ptype"]
+    load_on = [sdb.All()]
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:

--- a/sdb/commands/pyfilter.py
+++ b/sdb/commands/pyfilter.py
@@ -26,6 +26,7 @@ import sdb
 class PyFilter(sdb.Command):
 
     names = ["pyfilter"]
+    load_on = [sdb.All()]
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:

--- a/sdb/commands/sizeof.py
+++ b/sdb/commands/sizeof.py
@@ -47,6 +47,7 @@ class SizeOf(sdb.Command):
     """
 
     names = ["sizeof"]
+    load_on = [sdb.All()]
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:

--- a/sdb/commands/spl/avl.py
+++ b/sdb/commands/spl/avl.py
@@ -27,7 +27,7 @@ class Avl(sdb.Walker):
 
     names = ["avl"]
     input_type = "avl_tree_t *"
-    load_on = [sdb.Module("zfs")]
+    load_on = [sdb.Module("spl")]
 
     def _helper(self, node: drgn.Object, offset: int) -> Iterable[drgn.Object]:
         if sdb.is_null(node):

--- a/sdb/commands/spl/avl.py
+++ b/sdb/commands/spl/avl.py
@@ -27,6 +27,7 @@ class Avl(sdb.Walker):
 
     names = ["avl"]
     input_type = "avl_tree_t *"
+    load_on = [sdb.Module("zfs")]
 
     def _helper(self, node: drgn.Object, offset: int) -> Iterable[drgn.Object]:
         if sdb.is_null(node):

--- a/sdb/commands/spl/multilist.py
+++ b/sdb/commands/spl/multilist.py
@@ -26,6 +26,7 @@ from sdb.commands.spl.spl_list import SPLList
 class MultiList(sdb.Walker):
     names = ["multilist"]
     input_type = "multilist_t *"
+    load_on = [sdb.Module("zfs")]
 
     def walk(self, obj: drgn.Object) -> Iterable[drgn.Object]:
         for i in range(obj.ml_num_sublists):

--- a/sdb/commands/spl/multilist.py
+++ b/sdb/commands/spl/multilist.py
@@ -26,7 +26,7 @@ from sdb.commands.spl.spl_list import SPLList
 class MultiList(sdb.Walker):
     names = ["multilist"]
     input_type = "multilist_t *"
-    load_on = [sdb.Module("zfs")]
+    load_on = [sdb.Module("spl")]
 
     def walk(self, obj: drgn.Object) -> Iterable[drgn.Object]:
         for i in range(obj.ml_num_sublists):

--- a/sdb/commands/spl/spl_kmem_caches.py
+++ b/sdb/commands/spl/spl_kmem_caches.py
@@ -35,7 +35,7 @@ class SplKmemCaches(sdb.Locator, sdb.PrettyPrinter):
 
     input_type = "spl_kmem_cache_t *"
     output_type = "spl_kmem_cache_t *"
-    load_on = [sdb.Module("zfs")]
+    load_on = [sdb.Module("spl")]
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:
@@ -223,7 +223,7 @@ class SplKmemCacheWalker(sdb.Walker):
 
     names = ["spl_cache"]
     input_type = "spl_kmem_cache_t *"
-    load_on = [sdb.Module("zfs")]
+    load_on = [sdb.Module("spl")]
 
     def walk(self, obj: drgn.Object) -> Iterable[drgn.Object]:
         if kmem.backed_by_linux_cache(obj):

--- a/sdb/commands/spl/spl_kmem_caches.py
+++ b/sdb/commands/spl/spl_kmem_caches.py
@@ -35,6 +35,7 @@ class SplKmemCaches(sdb.Locator, sdb.PrettyPrinter):
 
     input_type = "spl_kmem_cache_t *"
     output_type = "spl_kmem_cache_t *"
+    load_on = [sdb.Module("zfs")]
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:
@@ -222,6 +223,7 @@ class SplKmemCacheWalker(sdb.Walker):
 
     names = ["spl_cache"]
     input_type = "spl_kmem_cache_t *"
+    load_on = [sdb.Module("zfs")]
 
     def walk(self, obj: drgn.Object) -> Iterable[drgn.Object]:
         if kmem.backed_by_linux_cache(obj):

--- a/sdb/commands/spl/spl_list.py
+++ b/sdb/commands/spl/spl_list.py
@@ -25,7 +25,7 @@ import sdb
 class SPLList(sdb.Walker):
     names = ["spl_list"]
     input_type = "list_t *"
-    load_on = [sdb.Module("zfs")]
+    load_on = [sdb.Module("spl")]
 
     def walk(self, obj: drgn.Object) -> Iterable[drgn.Object]:
         offset = int(obj.list_offset)

--- a/sdb/commands/spl/spl_list.py
+++ b/sdb/commands/spl/spl_list.py
@@ -25,6 +25,7 @@ import sdb
 class SPLList(sdb.Walker):
     names = ["spl_list"]
     input_type = "list_t *"
+    load_on = [sdb.Module("zfs")]
 
     def walk(self, obj: drgn.Object) -> Iterable[drgn.Object]:
         offset = int(obj.list_offset)

--- a/sdb/commands/sum.py
+++ b/sdb/commands/sum.py
@@ -41,6 +41,7 @@ class SdbSum(sdb.Command):
     """
 
     names = ["sum"]
+    load_on = [sdb.All()]
 
     def _call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
         result = 0

--- a/sdb/commands/tail.py
+++ b/sdb/commands/tail.py
@@ -36,6 +36,7 @@ class Tail(sdb.Command):
     """
 
     names = ["tail"]
+    load_on = [sdb.All()]
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:

--- a/sdb/commands/type.py
+++ b/sdb/commands/type.py
@@ -32,6 +32,7 @@ class Type(sdb.SingleInputCommand):
     """
 
     names = ["type"]
+    load_on = [sdb.All()]
 
     def _call_one(self, obj: drgn.Object) -> None:
         print(obj.type_)

--- a/sdb/commands/zfs/arc.py
+++ b/sdb/commands/zfs/arc.py
@@ -26,6 +26,7 @@ class ARCStats(sdb.Locator, sdb.PrettyPrinter):
     names = ["arc"]
     input_type = "arc_stats_t *"
     output_type = "arc_stats_t *"
+    load_on = [sdb.Module("zfs"), sdb.Library("libzpool")]
 
     @staticmethod
     def print_stats(obj: drgn.Object) -> None:

--- a/sdb/commands/zfs/btree.py
+++ b/sdb/commands/zfs/btree.py
@@ -51,6 +51,7 @@ class Btree(sdb.Walker):
 
     names = ["zfs_btree"]
     input_type = "zfs_btree_t *"
+    load_on = [sdb.Module("zfs"), sdb.Library("libzpool")]
 
     def __init__(self,
                  args: Optional[List[str]] = None,

--- a/sdb/commands/zfs/dbuf.py
+++ b/sdb/commands/zfs/dbuf.py
@@ -29,6 +29,7 @@ class Dbuf(sdb.Locator, sdb.PrettyPrinter):
     names = ["dbuf"]
     input_type = "dmu_buf_impl_t *"
     output_type = "dmu_buf_impl_t *"
+    load_on = [sdb.Module("zfs"), sdb.Library("libzpool")]
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:

--- a/sdb/commands/zfs/histograms.py
+++ b/sdb/commands/zfs/histograms.py
@@ -62,6 +62,7 @@ class ZFSHistogram(sdb.Command):
     """
 
     names = ["zfs_histogram", "zhist"]
+    load_on = [sdb.Module("zfs"), sdb.Library("libzpool")]
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:

--- a/sdb/commands/zfs/metaslab.py
+++ b/sdb/commands/zfs/metaslab.py
@@ -32,6 +32,7 @@ class Metaslab(sdb.Locator, sdb.PrettyPrinter):
     names = ["metaslab"]
     input_type = "metaslab_t *"
     output_type = "metaslab_t *"
+    load_on = [sdb.Module("zfs"), sdb.Library("libzpool")]
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:

--- a/sdb/commands/zfs/range_tree.py
+++ b/sdb/commands/zfs/range_tree.py
@@ -27,6 +27,7 @@ from sdb.command import Cast
 class RangeTree(sdb.PrettyPrinter):
     names = ['range_tree']
     input_type = 'range_tree_t *'
+    load_on = [sdb.Module("zfs"), sdb.Library("libzpool")]
 
     def pretty_print(self, objs: Iterable[drgn.Object]) -> None:
 
@@ -70,6 +71,7 @@ class RangeSeg(sdb.Locator):
     depending on what kind of range_tree_t this is.
     """
     names = ['range_seg']
+    load_on = [sdb.Module("zfs"), sdb.Library("libzpool")]
 
     @sdb.InputHandler('range_tree_t *')
     def from_range_tree(self, rt: drgn.Object) -> Iterable[drgn.Object]:

--- a/sdb/commands/zfs/spa.py
+++ b/sdb/commands/zfs/spa.py
@@ -30,6 +30,7 @@ class Spa(sdb.Locator, sdb.PrettyPrinter):
     names = ["spa"]
     input_type = "spa_t *"
     output_type = "spa_t *"
+    load_on = [sdb.Module("zfs"), sdb.Library("libzpool")]
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:

--- a/sdb/commands/zfs/vdev.py
+++ b/sdb/commands/zfs/vdev.py
@@ -30,6 +30,7 @@ class Vdev(sdb.Locator, sdb.PrettyPrinter):
     names = ["vdev"]
     input_type = "vdev_t *"
     output_type = "vdev_t *"
+    load_on = [sdb.Module("zfs"), sdb.Library("libzpool")]
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:

--- a/sdb/commands/zfs/zfs_dbgmsg.py
+++ b/sdb/commands/zfs/zfs_dbgmsg.py
@@ -29,6 +29,7 @@ class ZfsDbgmsg(sdb.Locator, sdb.PrettyPrinter):
     names = ["zfs_dbgmsg"]
     input_type = "zfs_dbgmsg_t *"
     output_type = "zfs_dbgmsg_t *"
+    load_on = [sdb.Module("zfs"), sdb.Library("libzpool")]
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:

--- a/sdb/commands/zfs/zio.py
+++ b/sdb/commands/zfs/zio.py
@@ -58,6 +58,7 @@ class Zio(sdb.Locator, sdb.PrettyPrinter):
     names = ["zio"]
     input_type = "zio_t *"
     output_type = "zio_t *"
+    load_on = [sdb.Module("zfs"), sdb.Library("libzpool")]
 
     @classmethod
     def _init_parser(cls, name: str) -> argparse.ArgumentParser:

--- a/sdb/internal/cli.py
+++ b/sdb/internal/cli.py
@@ -214,6 +214,8 @@ def main() -> None:
     except PermissionError as err:
         print("sdb: " + str(err))
         return
+    sdb.target.set_prog(prog)
+    sdb.register_commands()
 
     repl = REPL(prog, list(sdb.get_registered_commands().keys()))
     repl.enable_history(os.getenv('SDB_HISTORY_FILE', '~/.sdb_history'))

--- a/sdb/internal/repl.py
+++ b/sdb/internal/repl.py
@@ -104,7 +104,7 @@ class REPL:
         """
         # pylint: disable=broad-except
         try:
-            for obj in invoke(self.target, [], input_):
+            for obj in invoke([], input_):
                 print(obj.format_(dereference=False))
         except CommandArgumentsError:
             #

--- a/sdb/pipeline.py
+++ b/sdb/pipeline.py
@@ -84,7 +84,7 @@ def execute_pipeline(first_input: Iterable[drgn.Object],
     yield from massage_input_and_call(pipeline[-1], this_input)
 
 
-def invoke(myprog: drgn.Program, first_input: Iterable[drgn.Object],
+def invoke(first_input: Iterable[drgn.Object],
            line: str) -> Iterable[drgn.Object]:
     """
     This function intends to integrate directly with the SDB REPL, such
@@ -92,7 +92,6 @@ def invoke(myprog: drgn.Program, first_input: Iterable[drgn.Object],
     function is responsible for converting that string into the
     appropriate pipeline of Command objects, and executing it.
     """
-    target.set_prog(myprog)
 
     #
     # Build the pipeline by constructing each of the commands we want to

--- a/sdb/target.py
+++ b/sdb/target.py
@@ -119,8 +119,9 @@ def type_canonicalize_name(type_name: str) -> str:
     # This is a workaround while we don't have module/library lookup in drgn.
     try:
         return type_canonical_name(prog.type(type_name))
-    except LookupError as e:
+    except LookupError:
         return type_name
+
 
 def type_canonicalize_size(t: Union[drgn.Type, str]) -> int:
     """
@@ -151,24 +152,59 @@ def type_equals(a: drgn.Type, b: drgn.Type) -> bool:
     """
     return type_canonical_name(a) == type_canonical_name(b)
 
+
+#pylint: disable=too-few-public-methods
 class All:
-    pass
+    """
+    Commands that specify this runtime should always be loaded; these commands
+    are universally applicable to all debugging scenarios.
+    """
 
+
+#pylint: disable=too-few-public-methods
 class Kernel:
-    pass
+    """
+    Commands that specify this runtime should be loaded any time a kernel
+    is being analyzed.
+    """
 
+
+#pylint: disable=too-few-public-methods
 class Userland:
-    pass
+    """
+    Commands that specify this runtime should be loaded any time a userland
+    program is being analyzed.
+    """
 
+
+#pylint: disable=too-few-public-methods
 class Module:
+    """
+    Commands that specify this runtime should be loaded whenever the kernel
+    module with the provided name is loaded.
+    """
+
     def __init__(self, name: str) -> None:
         self.name = name
 
+
+#pylint: disable=too-few-public-methods
 class Library:
+    """
+    Commands that specify this runtime should be loaded whenever the library
+    with the provided name is loaded.
+    """
+
     def __init__(self, name: str) -> None:
         self.name = name
+
 
 Runtime = Union[All, Kernel, Userland, Module, Library]
 
+
 def get_runtimes() -> Tuple[bool, List[str]]:
+    """
+    Returns whether we are in kernel or user mode, and the list of loaded
+    modules or libraries.
+    """
     return (get_target_flags() & drgn.ProgramFlags.IS_LINUX_KERNEL, [])

--- a/sdb/target.py
+++ b/sdb/target.py
@@ -116,7 +116,10 @@ def type_canonicalize_name(type_name: str) -> str:
     """
     Return the "canonical name" of this type name.  See type_canonicalize().
     """
+    #
     # This is a workaround while we don't have module/library lookup in drgn.
+    # See https://github.com/delphix/cloud-init/issues/74 for details.
+    #
     try:
         return type_canonical_name(prog.type(type_name))
     except LookupError:

--- a/tests/integration/infra.py
+++ b/tests/integration/infra.py
@@ -193,7 +193,9 @@ def sdb_invoke(objs: Iterable[drgn.Object], line: str) -> Iterable[drgn.Object]:
     state of objects that is not part of the output in stdout.
     """
     assert TEST_PROGRAM
-    return list(sdb.invoke(TEST_PROGRAM, objs, line))
+    sdb.target.set_prog(TEST_PROGRAM)
+    sdb.register_commands()
+    return list(sdb.invoke(objs, line))
 
 
 def slurp_output_file(dump_name: str, modname: str, cmd: str) -> str:

--- a/tests/integration/infra.py
+++ b/tests/integration/infra.py
@@ -178,6 +178,8 @@ def repl_invoke(cmd: str) -> int:
     the SDB repl.
     """
     assert TEST_PROGRAM
+    sdb.target.set_prog(TEST_PROGRAM)
+    sdb.register_commands()
     return TEST_REPL.eval_cmd(cmd)
 
 

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -211,4 +211,6 @@ def invoke(prog: drgn.Program, objs: Iterable[drgn.Object],
     Dispatch to sdb.invoke, but also drain the generator it returns, so
     the tests can more easily access the returned objects.
     """
-    return list(sdb.invoke(prog, objs, line))
+    sdb.target.set_prog(prog)
+    sdb.register_commands()
+    return list(sdb.invoke(objs, line))


### PR DESCRIPTION
= Problem
See #303 

= Solution
See #303. Specifically, the load_on field is added to every command, which allows a command to specify a list of runtimes in which it should be loaded. Until drgn supports providing a list of loaded modules and libraries, we choose to load all module-specific commands whenever we're in the kernel, and all library-specific ones whenever we're in userland. There are also a couple of small changes to prevent errors from being thrown when we try to interact with types that aren't loaded because their library/module isn't present.

= Testing
Ran against a running kernel and userland core files, verified that appropriate commands appeared in each and behaved as expected.

= Github Issue Tracker Automation
Closes #303 
