### PR TITLE
DLPX-86793 sdb: stacks is broken for 5.15 kernels

### DIFF
--- a/sdb/commands/linux/stacks.py
+++ b/sdb/commands/linux/stacks.py
@@ -207,7 +207,13 @@ class KernelStacks(sdb.Locator, sdb.PrettyPrinter):
 
     @staticmethod
     def task_struct_get_state(task: drgn.Object) -> str:
-        state = task.state.value_()
+        task_struct_type = task.type_.type
+        state = 0
+        if task_struct_type.has_member('__state'):
+            state = task.member_('__state').value_()
+        else:
+            # For kernels older than v5.14
+            state = task.state.value_()
         if state == 0x402:
             return "IDLE"
 


### PR DESCRIPTION
Before this patch `sdb` fails with the following error in our most current kernels:
```
sdb> stacks -m zfs
TASK_STRUCT        STATE             COUNT
==========================================
sdb encountered an internal error due to a bug. Here's the
information you need to file the bug:
----------------------------------------------------------
Target Info:
	ProgramFlags.IS_LIVE|IS_LINUX_KERNEL
	Platform(<Architecture.X86_64: 1>, <PlatformFlags.IS_LITTLE_ENDIAN|IS_64_BIT: 3>)

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/sdb/internal/repl.py", line 107, in eval_cmd
    for obj in invoke([], input_):
  File "/usr/lib/python3/dist-packages/sdb/pipeline.py", line 152, in invoke
    yield from execute_pipeline(first_input, pipeline)
  File "/usr/lib/python3/dist-packages/sdb/pipeline.py", line 84, in execute_pipeline
    yield from massage_input_and_call(pipeline[-1], this_input)
  File "/usr/lib/python3/dist-packages/sdb/pipeline.py", line 67, in massage_input_and_call
    yield from cmd.call(objs)
  File "/usr/lib/python3/dist-packages/sdb/command.py", line 413, in call
    yield from self.__invalid_memory_objects_check(
  File "/usr/lib/python3/dist-packages/sdb/command.py", line 358, in __invalid_memory_objects_check
    for obj in objs:
  File "/usr/lib/python3/dist-packages/sdb/command.py", line 625, in _call
    self.pretty_print(self.caller(objs))
  File "/usr/lib/python3/dist-packages/sdb/commands/linux/stacks.py", line 401, in pretty_print
    self.print_stacks(filter(self.match_stack, objs))
  File "/usr/lib/python3/dist-packages/sdb/commands/linux/stacks.py", line 376, in print_stacks
    for stack_key, tasks in KernelStacks.aggregate_stacks(objs):
  File "/usr/lib/python3/dist-packages/sdb/commands/linux/stacks.py", line 369, in aggregate_stacks
    stack_key = (KernelStacks.task_struct_get_state(task),
  File "/usr/lib/python3/dist-packages/sdb/commands/linux/stacks.py", line 210, in task_struct_get_state
    state = task.state.value_()
AttributeError: 'struct task_struct' has no member 'state'
----------------------------------------------------------
Link: https://github.com/delphix/sdb/issues/new
```

This patch fixes that regression

= Github Issue Tracker Automation

Closes #325