### PR TITLE
DLPX-92461 Add libkdumpfile10 and python3-drgn as dependencies of sdb to remove dependency on internal forks

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,5 +7,5 @@ Build-Depends: debhelper (>= 9), dh-python, python3
 
 Package: sdb
 Architecture: any
-Depends: ${shlibs:Depends}, ${python3:Depends}
+Depends: libkdumpfile10, python3-drgn, ${shlibs:Depends}, ${python3:Depends}
 Description: The Slick/Simple Debugger


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

libkdumpfile and drgn are currently built from internal sources. These 2 repos
have had minimal changes authored by Delphix and all of them are build-related or
related to the python2-3 migration. Maintaining internal forks causes overheads.
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

To reduce the dependency of using internal forks, this change adds these 2 packages
as dependencies of `sdb` so that https://github.com/delphix/linux-pkg/pull/325 can proceed
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

https://ops-jenkins.eng-tools-prd.aws.delphixcloud.com/job/linux-pkg/job/os-upgrade/job/build-package/job/sdb/job/pre-push/10/console
Some manual tests:
```
ubuntu@ip-10-110-219-58:~$ aws s3 cp s3://dev-de-images/builds/jenkins-ops/linux-pkg/os-upgrade/build-package/sdb/pre-push/10/sdb_1.0.0-1delphix.2024.10.17.19.19_amd64.deb .
download: s3://dev-de-images/builds/jenkins-ops/linux-pkg/os-upgrade/build-package/sdb/pre-push/10/sdb_1.0.0-1delphix.2024.10.17.19.19_amd64.deb to ./sdb_1.0.0-1delphix.2024.10.17.19.19_amd64.deb
ubuntu@ip-10-110-219-58:~$ sudo dpkg -i sdb_1.0.0-1delphix.2024.10.17.19.19_amd64.deb
Selecting previously unselected package sdb.
(Reading database ... 122844 files and directories currently installed.)
Preparing to unpack sdb_1.0.0-1delphix.2024.10.17.19.19_amd64.deb ...
Unpacking sdb (1.0.0-1delphix.2024.10.17.19.19) ...
dpkg: dependency problems prevent configuration of sdb:
 sdb depends on libkdumpfile10; however:
  Package libkdumpfile10 is not installed.
 sdb depends on python3-drgn; however:
  Package python3-drgn is not installed.

dpkg: error processing package sdb (--install):
 dependency problems - leaving unconfigured
Errors were encountered while processing:
 sdb
ubuntu@ip-10-110-219-58:~$ sudo sdb
Traceback (most recent call last):
  File "/usr/bin/sdb", line 33, in <module>
    sys.exit(load_entry_point('sdb==0.1.0', 'console_scripts', 'sdb')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/bin/sdb", line 25, in importlib_load_entry_point
    return next(matches).load()
           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/importlib/metadata/__init__.py", line 205, in load
    module = import_module(match.group('module'))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1310, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1310, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 995, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/usr/lib/python3/dist-packages/sdb/__init__.py", line 35, in <module>
    from sdb.target import (create_object, get_object, get_prog, get_type,
  File "/usr/lib/python3/dist-packages/sdb/target.py", line 46, in <module>
    import drgn
ModuleNotFoundError: No module named 'drgn'
```
After installing python3-drgn and libkdumpfile
```
ubuntu@ip-10-110-219-58:~$ sudo sdb
sdb: missing some debugging symbols (see https://drgn.readthedocs.io/en/latest/getting_debugging_symbols.html):
  kernel (could not find vmlinux for 6.8.0-1013-aws)
  kernel modules (could not find loaded kernel modules: could not find 'struct module')
sdb> find_task 1
sdb encountered an internal error due to a bug. Here's the
information you need to file the bug:
----------------------------------------------------------
Target Info:
	ProgramFlags.IS_LINUX_KERNEL|IS_LIVE|IS_LOCAL
	Platform(<Architecture.X86_64: 1>, <PlatformFlags.IS_64_BIT|IS_LITTLE_ENDIAN: 3>)

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/sdb/internal/repl.py", line 107, in eval_cmd
    for obj in invoke([], input_):
  File "/usr/lib/python3/dist-packages/sdb/pipeline.py", line 152, in invoke
    yield from execute_pipeline(first_input, pipeline)
  File "/usr/lib/python3/dist-packages/sdb/pipeline.py", line 84, in execute_pipeline
    yield from massage_input_and_call(pipeline[-1], this_input)
  File "/usr/lib/python3/dist-packages/sdb/pipeline.py", line 43, in massage_input_and_call
    yield from cmd.call(objs)
  File "/usr/lib/python3/dist-packages/sdb/command.py", line 413, in call
    yield from self.__invalid_memory_objects_check(
  File "/usr/lib/python3/dist-packages/sdb/command.py", line 358, in __invalid_memory_objects_check
    for obj in objs:
  File "/usr/lib/python3/dist-packages/sdb/commands/linux/process.py", line 93, in _call
    yield find_task(sdb.get_prog(), pid)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/drgn/helpers/common/prog.py", line 213, in wrapper
    return f(args[0], None, *args[1:], **kwds)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/drgn/helpers/linux/pid.py", line 84, in find_task
    ns = prog["init_pid_ns"].address_of_()
         ~~~~^^^^^^^^^^^^^^^
KeyError: 'init_pid_ns'
----------------------------------------------------------
Link: https://github.com/delphix/sdb/issues/new
```
I think this is expected because the VM I used is a bootstrapped 24.04 VM without kernel debug symbols.

</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
