### PR TITLE
DLPX-90487 sdb stacks appears to loop resulting in many repeated stack frames

### DIFF
--- a/sdb/commands/linux/stacks.py
+++ b/sdb/commands/linux/stacks.py
@@ -369,6 +369,12 @@ class KernelStacks(sdb.Locator, sdb.PrettyPrinter):
             stack_aggr[stack_key].append(task)
         return sorted(stack_aggr.items(), key=lambda x: len(x[1]), reverse=True)
 
+    @staticmethod
+    def frame_string(frame_info: str, count: int) -> str:
+        if count > 1:
+            return f"{frame_info} ({str(count)})\n"
+        return f"{frame_info}\n"
+
     def print_stacks(self, objs: Iterable[drgn.Object]) -> None:
         self.print_header()
         for stack_key, tasks in KernelStacks.aggregate_stacks(objs):
@@ -382,16 +388,47 @@ class KernelStacks(sdb.Locator, sdb.PrettyPrinter):
                 task_ptr = hex(tasks[0].value_())
                 stacktrace_info += f"{task_ptr:<18s} {task_state:<16s} {len(tasks):6d}\n"
 
+            #
+            # List the frames for each task in the stack. Ignore frames
+            # with a program counter of zero (sometimes the stack will be
+            # padded out with zeros). Aggregate frames with the same program
+            # counter and offset.
+            #
             frame_pcs: Tuple[int, ...] = stack_key[1]
+            last_frame_pc = 0x0
+            last_offset = 0x0
+            count = 0
             for frame_pc in frame_pcs:
                 try:
+                    # ignore frames with a program counter of zero
+                    if frame_pc == 0x0:
+                        continue
                     sym = sdb.get_symbol(frame_pc)
                     func = sym.name
                     offset = frame_pc - sym.address
+                    if frame_pc == last_frame_pc and offset == last_offset:
+                        count += 1
+                        continue
+                    # emit the last frame we have accumulated
+                    if count > 0:
+                        stacktrace_info += KernelStacks.frame_string(frame_info, count)
+                    frame_info = f"{'':18s}{func}+0x{hex(offset)}"
+                    last_frame_pc = frame_pc
+                    last_offset = offset
+                    count = 1
                 except LookupError:
-                    func = hex(frame_pc)
-                    offset = 0x0
-                stacktrace_info += f"{'':18s}{func}+{hex(offset)}\n"
+                    if frame_pc == last_frame_pc:
+                        count += 1
+                        continue
+                    # emit any previous frame info we have accumulated
+                    if count > 0:
+                        stacktrace_info += KernelStacks.frame_string(frame_info, count)
+                    frame_info = f"{'':18s}{hex(frame_pc)}+0x0"
+                    last_frame_pc = frame_pc
+                    count = 1
+            # emit the final frame if we have one
+            if count > 0:
+                stacktrace_info += KernelStacks.frame_string(frame_info, count)
             print(stacktrace_info)
 
     def pretty_print(self, objs: Iterable[drgn.Object]) -> None:


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

Often, when using the `stacks` command, the stack listing will be very long
(1024 lines) with most of the stack being `0x0+0x0` or some other "cruft":
```
0xffff9debf71ecc80 INTERRUPTIBLE       493
                  __schedule+0x2c8
                  __schedule+0x2c8
                  schedule+0x69
                  schedule_timeout+0x18f
                  svc_recv+0x45e
                  svc_recv+0x45e
                  nfsd+0xdb
                  kthread+0x127
                  ret_from_fork+0x1f
                  0x0+0x0
                  0x0+0x0
                  0x0+0x0
                  0x0+0x0
                  0x0+0x0
                  0x0+0x0
                  0x0+0x0
                  ...
```
</details>

<details>
<summary><h2> Evaluation </h2></summary>

The issue does not appear to be in the stack trace output code, but rather
in the drgn code that generates the array of stack task pointers. Sometimes
this array appears to be non-terminated and instead has the max length
(of 1024) with “cruft” (usually zeros) padding out the end after the stack.
</details>

<details open>
<summary><h2> Solution </h2></summary>

The stack printing algorithm has been modified to ignore task frames that
have a program counter value of 0x0. The algorithm will also aggregate
adjacent frames where the program counter and offset are the same:
```
0xffff9debf71ecc80 INTERRUPTIBLE       493
                  __schedule+0x2c8 (2)
                  schedule+0x69
                  schedule_timeout+0x18f
                  svc_recv+0x45e (2)
                  nfsd+0xdb
                  kthread+0x127
                  ret_from_fork+0x1f
```
</details>


<details>
<summary><h2> Testing Done </h2></summary>

Verified that the stack prints as expected on a system where the old
algorithm printed long stacks.
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
