### PR TITLE
DLPX-93639 LTS 24.04: Upgrade fails due to drgn conflict with upstream python3-drgn package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,5 +7,5 @@ Build-Depends: debhelper (>= 9), dh-python, python3
 
 Package: sdb
 Architecture: any
-Depends: libkdumpfile10, python3-drgn, ${shlibs:Depends}, ${python3:Depends}
+Depends: libkdumpfile10, drgn, ${shlibs:Depends}, ${python3:Depends}
 Description: The Slick/Simple Debugger


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
Upgrade from 20.04 to 24.04 fails due to package name difference of our internal version of the "drgn" package, and ubuntu's package.
</details>

<details open>
<summary><h2> Solution </h2></summary>
The solution here, is to keep using our internal "drgn" package, rather than ubuntu's.
</details>
