### PR TITLE
DLPX-94103 LTS 24.04: update sdb for Ubuntu 24.04 appliance

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,5 +7,5 @@ Build-Depends: debhelper (>= 9), dh-python, python3
 
 Package: sdb
 Architecture: any
-Depends: ${shlibs:Depends}, ${python3:Depends}
+Depends: drgn, ${shlibs:Depends}, ${python3:Depends}
 Description: The Slick/Simple Debugger


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
We need to port the changes made on the os-upgrade branch to develop, for the 2025.4.0.0 release.
</details>

<details open>
<summary><h2> Solution </h2></summary>

- Note, this will need to be integrated simultaneously with all the other LTS changes on other repositories, after code-complete.
- This PR has all the changes made on the os-upgrade branch, cherry-picked and squashed into a single commit for integration on the develop branch.
  - DLPX-93685 LTS 24.04: Upgrade fails due to libkdumpfile conflict with upstream libkdumpfile10 package (#354)
  - DLPX-93639 LTS 24.04: Upgrade fails due to drgn conflict with upstream python3-drgn package (#353)
  - DLPX-92461 Add libkdumpfile10 and python3-drgn as dependencies of sdb to remove dependency on internal forks
  
</details>
