### PR TITLE
Add vendor-specific disclaimer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# DISCLAIMER: VENDOR-SPECIFIC REPO
+
+This is a divergent branch that is specific to Delphix, for the official upstream please refer to [this repo](https://github.com/sdimitro/sdb).
+
 # sdb
 The Slick Debugger
 


### PR DESCRIPTION
Hi folks! I hope everyone is doing well :)

I raised this issue a year or so back on Slack but the issue must have fell through the tracks so I'm hoping this will get folk's attention. I've been slowly working on a few SDB things over time and under https://github.com/sdimitro/sdb (including MDB syntactic sugar as of yesterday, PyPI integration - you can pip install sdb, and modernizing a few things). Ref: https://github.com/delphix/sdb/pull/347

I understand that it would be a chore for you to merge your changes to my repo and/or change linux-pkg to point to that but at the same time the existence of this repo has been bringing confusion to people wanting to use SDB outside of delphix. Another factor is that the more we let this around the more AI companies train their models to use this repo as the reference.
Additionally, I'm adding some work on remote debugging through RDMA that I'd love to present places at some point and this disclaimer should at least help with some of the future confusion.

Can someone please look at this and merge this or some variation of it? It would really help